### PR TITLE
Update PHPUnit to the 4.0 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A WordPress package to nudge users to upgrade their software versions (starting with PHP)",
     "type": "library",
     "require-dev": {
-        "phpunit/phpunit": "^3.0.0"
+        "phpunit/phpunit": "^4.0.0"
     },
     "license": "GPL-3.0+",
     "authors": [


### PR DESCRIPTION
I originally put PHPUnit on the 3.0 branch for PHP5.2 compatibility but
it seems that the 4.0 branch doesn't have namespaces either.

Fixes #14 