### PR TITLE
Rename facade function from `CheckVersions` to `check_versions`.

### DIFF
--- a/src/facades/wordpress.php
+++ b/src/facades/wordpress.php
@@ -1,12 +1,12 @@
 <?php
 
-if ( ! function_exists( 'CheckVersions' ) ) {
+if ( ! function_exists( 'check_versions' ) ) {
 	/**
 	 * Facade to quickly check if version requirements are met.
 	 *
 	 * @param array $requirements The requirements to check.
 	 */
-	function CheckVersions( $requirements ) {
+	function check_versions( $requirements ) {
 		// Only show for admin users.
 		if ( ! current_user_can( 'manage_options' ) || ! is_array( $requirements ) ) {
 			return;


### PR DESCRIPTION
If the facade is not a class but a function, the name should not use StudlyCaps, but rather snake_case.