### PR TITLE
Fix broken config include.

### DIFF
--- a/src/facades/wordpress.php
+++ b/src/facades/wordpress.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'CheckVersions' ) ) {
 			return;
 		}
 
-		$config  = include_once dirname( __FILE__ ) . '/../configs/default.php';
+		$config  = include dirname( __FILE__ ) . '/../configs/default.php';
 		$checker = new Whip_RequirementsChecker( $config );
 
 		foreach ( $requirements as $component => $versionComparison ) {


### PR DESCRIPTION
The `$config` can be read with `include_once` within a function, as this will only work the first time around. On all subsequent calls, `include_once` will return `true` instead of the contents, as the file had already been included before.