### PR TITLE
Correct `Whip_RequirementsChecker::getMostRecentMessage()` return type-hint.

### DIFF
--- a/src/Whip_RequirementsChecker.php
+++ b/src/Whip_RequirementsChecker.php
@@ -143,7 +143,7 @@ class Whip_RequirementsChecker {
 	/**
 	 * Gets the most recent message from the message manager.
 	 *
-	 * @return string The latest message.
+	 * @return Whip_Message The latest message.
 	 */
 	public function getMostRecentMessage() {
 		return $this->messageMananger->getLatestMessage();


### PR DESCRIPTION
The type-hint should be `Whip_Message`, not `string`.