### PR TITLE
Use the most specific PHPUnit assert method available.

### DIFF
--- a/tests/RequirementsCheckerTest.php
+++ b/tests/RequirementsCheckerTest.php
@@ -100,7 +100,7 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 		$this->assertNotEmpty( $recentMessage  );
 		$this->assertInternalType( 'string', $recentMessage->body() );
 		$this->assertFalse( $checker->hasMessages() );
-		$this->assertTrue( get_class( $recentMessage ) === 'Whip_UpgradePhpMessage' );
+		$this->assertInstanceOf( 'Whip_UpgradePhpMessage', $recentMessage );
 	}
 
 	public function testCheckIfRequirementIsNotFulfilled() {
@@ -116,7 +116,7 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertNotEmpty( $recentMessage  );
 		$this->assertFalse( $checker->hasMessages() );
-		$this->assertTrue( get_class( $recentMessage ) === 'Whip_InvalidVersionRequirementMessage' );
+		$this->assertInstanceOf( 'Whip_InvalidVersionRequirementMessage', $recentMessage );
 		$this->assertStringStartsWith( 'Invalid version detected', $recentMessage->body() );
 	}
 


### PR DESCRIPTION
Always use the most specific assert to improve the test failure output.