### PR TITLE
Optimize conditional return.

### DIFF
--- a/src/Whip_RequirementsChecker.php
+++ b/src/Whip_RequirementsChecker.php
@@ -89,11 +89,7 @@ class Whip_RequirementsChecker {
 		$required_version = $requirement->version();
 
 		if ( in_array( $requirement->operator(), array( '=', '==', '===' ) ) ) {
-			if ( version_compare( $available_version, $required_version ) === -1 ) {
-				return false;
-			}
-
-			return true;
+			return -1 !== version_compare( $available_version, $required_version );
 		}
 
 		return version_compare( $available_version, $required_version, $requirement->operator() );


### PR DESCRIPTION
For boolean returns, an if-clause can be avoided by directly returning the evaulated condition.