### PR TITLE
Correct versioned requirement type-hint.

### DIFF
--- a/src/messages/Whip_InvalidVersionRequirementMessage.php
+++ b/src/messages/Whip_InvalidVersionRequirementMessage.php
@@ -17,7 +17,7 @@ class Whip_InvalidVersionRequirementMessage implements Whip_Message {
 	 * @param Whip_Requirement $requirement
 	 * @param                  $detected
 	 */
-	public function __construct( Whip_Requirement $requirement, $detected )
+	public function __construct( Whip_VersionRequirement $requirement, $detected )
 	{
 	    $this->requirement = $requirement;
 		$this->detected = $detected;


### PR DESCRIPTION
As the `body()` message makes use of the `Whip_VersionRequirement::version()` method, type-hinting against the pure interface is not enough. The interface `Whip_Requirement` interface does not have a `version()` method.