### PR TITLE
Prevent duplicate notices

### DIFF
--- a/src/presenters/Whip_WPMessagePresenter.php
+++ b/src/presenters/Whip_WPMessagePresenter.php
@@ -14,14 +14,18 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 	 */
 	public function __construct( Whip_Message $message ) {
 	    $this->message = $message;
-    }
+	}
 
-    /**
+	/**
 	 * Registers hooks to WordPress. This is a separate function so you can
 	 * control when the hooks are registered.
 	 */
 	public function register_hooks() {
-		add_action( 'admin_notices', array( $this, 'renderMessage' ) );
+		global $whip_admin_notices_added;
+		if ( null === $whip_admin_notices_added || ! $whip_admin_notices_added ) {
+			add_action( 'admin_notices', array( $this, 'renderMessage' ) );
+			$whip_admin_notices_added = true;
+		}
 	}
 
 	/**


### PR DESCRIPTION
When the `admin_notices` hook is created, raise a flag in a global variable to avoid hooking multiple times.

See #36 

I would like to add tests coverage to this whole class, but I'd need to add `10up/wp_mock`, `lucatume/function-mocker` or something similar to mock global functions such as `wp_kses`.

If that's not a problem, I can add tests to this PR in a separate commit.