### PR TITLE
Show notice every 4 weeks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
 
 
 install:
-- phpenv local 5.3
 - composer install
 - if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then composer remove --dev phpunit/phpunit; fi
 - phpenv local --unset

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: php
+dist: trusty
 php:
 - '7.1'
 - '7.0'
 - '5.6'
 - '5.5'
 - '5.4'
-- '5.3'
-- '5.2'
+
+matrix:
+    fast_finish: true
+    include:
+    - php: 5.2
+      dist: precise
+    - php: 5.3
+      dist: precise
+
 
 install:
 - phpenv local 5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ matrix:
 
 
 install:
-- composer install
+- phpenv local 5.6
+- composer selfupdate 1.0.0 --no-interaction
+- composer install --no-interaction
 - if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then composer remove --dev phpunit/phpunit; fi
 - phpenv local --unset
 

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
         ],
         "post-autoload-dump": [
             "xrstf\\Composer52\\Generator::onPostInstallCmd"
+        ],
+        "test": [
+            "vendor/bin/phpunit"
         ]
     }
 }

--- a/src/Whip_MessageDismisser.php
+++ b/src/Whip_MessageDismisser.php
@@ -11,14 +11,19 @@ class Whip_MessageDismisser {
 	/** @var string */
 	protected $currentTime;
 
+	/** @var int */
+	protected $threshold;
+
 	/**
 	 * Whip_MessageDismisser constructor.
 	 *
 	 * @param int                 $currentTime The current time.
+	 * @param int                 $threshold   The number of seconds till dismiss state expires.
 	 * @param Whip_DismissStorage $storage     The storage object handling storage of the time.
 	 */
-	public function __construct( $currentTime, Whip_DismissStorage $storage ) {
+	public function __construct( $currentTime, $threshold, Whip_DismissStorage $storage ) {
 		$this->currentTime = $currentTime;
+		$this->threshold   = $threshold;
 		$this->storage     = $storage;
 	}
 
@@ -35,18 +40,6 @@ class Whip_MessageDismisser {
 	 * @return bool True when stored value + threshold is bigger than current time.
 	 */
 	public function isDismissed() {
-		return ( ( $this->storage->get() + $this->getThreshold() ) > $this->currentTime );
+		return ( ( $this->storage->get() + $this->threshold ) > $this->currentTime );
 	}
-
-	/**
-	 * Returns the threshold.
-	 *
-	 * @return integer The total amount of seconds.
-	 */
-	protected function getThreshold() {
-		$numberOfWeeks = 4;
-
-		return ( WEEK_IN_SECONDS * $numberOfWeeks );
-	}
-
 }

--- a/src/Whip_MessageDismisser.php
+++ b/src/Whip_MessageDismisser.php
@@ -35,11 +35,11 @@ class Whip_MessageDismisser {
 	}
 
 	/**
-	 * Checks if the stored time is lower than the current time.
+	 * Checks if the current time is lower than the stored time extended by the threshold.
 	 *
-	 * @return bool True when stored value + threshold is bigger than current time.
+	 * @return bool True when current time is lower than stored value + threshold.
 	 */
 	public function isDismissed() {
-		return ( ( $this->storage->get() + $this->threshold ) > $this->currentTime );
+		return ( $this->currentTime <= ( $this->storage->get() + $this->threshold ) );
 	}
 }

--- a/src/Whip_MessageDismisser.php
+++ b/src/Whip_MessageDismisser.php
@@ -18,8 +18,8 @@ class Whip_MessageDismisser {
 	 * Whip_MessageDismisser constructor.
 	 *
 	 * @param int                 $currentTime The current time.
-	 * @param int                 $threshold   The number of seconds till dismiss state expires.
-	 * @param Whip_DismissStorage $storage     The storage object handling storage of the time.
+	 * @param int                 $threshold   The number of seconds the message will be dismissed.
+	 * @param Whip_DismissStorage $storage     Storage object to manage the dismissal state.
 	 */
 	public function __construct( $currentTime, $threshold, Whip_DismissStorage $storage ) {
 		$this->currentTime = $currentTime;

--- a/src/Whip_MessageDismisser.php
+++ b/src/Whip_MessageDismisser.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * A class to dismiss messages.
  */
@@ -10,45 +9,44 @@ class Whip_MessageDismisser {
 	protected $storage;
 
 	/** @var string */
-	protected $currentVersion;
+	protected $currentTime;
 
 	/**
 	 * Whip_MessageDismisser constructor.
 	 *
-	 * @param string              $currentVersion The current version of the installation.
-	 * @param Whip_DismissStorage $storage        The storage object handling storage of versioning.
+	 * @param int                 $currentTime The current time.
+	 * @param Whip_DismissStorage $storage     The storage object handling storage of the time.
 	 */
-	public function __construct( $currentVersion, Whip_DismissStorage $storage ) {
-		$this->currentVersion = $this->toMajorVersion( $currentVersion );
-		$this->storage        = $storage;
+	public function __construct( $currentTime, Whip_DismissStorage $storage ) {
+		$this->currentTime = $currentTime;
+		$this->storage     = $storage;
 	}
 
 	/**
 	 * Saves the version number to the storage to indicate the message as being dismissed.
 	 */
 	public function dismiss() {
-		$this->storage->set( $this->currentVersion );
+		$this->storage->set( $this->currentTime );
 	}
 
 	/**
-	 * Checks if the stored version is equal or higher than the version to check against.
+	 * Checks if the stored time is lower than the current time.
 	 *
-	 * @return bool True when saved version is equal or higher than the provided version.
+	 * @return bool True when stored value + threshold is bigger than current time.
 	 */
 	public function isDismissed() {
-		return version_compare( $this->storage->get(), $this->currentVersion, '>=' );
+		return ( ( $this->storage->get() + $this->getThreshold() ) > $this->currentTime );
 	}
 
 	/**
-	 * Converts the version number to a major version number.
+	 * Returns the threshold.
 	 *
-	 * @param string $versionToConvert The version to convert.
-	 *
-	 * @return string The major version number.
+	 * @return integer The total amount of seconds.
 	 */
-	protected function toMajorVersion( $versionToConvert ) {
-		$parts = explode( '.', $versionToConvert, 3 );
+	protected function getThreshold() {
+		$numberOfWeeks = 4;
 
-		return implode( '.', array_slice( $parts, 0, 2 ) );
+		return ( WEEK_IN_SECONDS * $numberOfWeeks );
 	}
+
 }

--- a/src/Whip_WPDismissOption.php
+++ b/src/Whip_WPDismissOption.php
@@ -11,23 +11,23 @@ class Whip_WPDismissOption implements Whip_DismissStorage {
 	/**
 	 * Saves the value to the options.
 	 *
-	 * @param string $dismissedVersion The value to save.
+	 * @param string $dismissedValue The value to save.
 	 *
 	 * @return bool True when successful.
 	 */
-	public function set( $dismissedVersion ) {
-		return update_option( $this->optionName, $dismissedVersion );
+	public function set( $dismissedValue ) {
+		return update_option( $this->optionName, $dismissedValue );
 	}
 
 	/**
 	 * Returns the value of the whip_dismissed option.
 	 *
-	 * @return string Returns the value of the option or an empty string when not set.
+	 * @return string|int Returns the value of the option or an empty string when not set.
 	 */
 	public function get() {
 		$dismissedOption = get_option( $this->optionName );
 		if ( ! $dismissedOption ) {
-			return '';
+			return 0;
 		}
 
 		return $dismissedOption;

--- a/src/Whip_WPDismissOption.php
+++ b/src/Whip_WPDismissOption.php
@@ -11,7 +11,7 @@ class Whip_WPDismissOption implements Whip_DismissStorage {
 	/**
 	 * Saves the value to the options.
 	 *
-	 * @param string $dismissedValue The value to save.
+	 * @param int $dismissedValue The value to save.
 	 *
 	 * @return bool True when successful.
 	 */
@@ -22,7 +22,7 @@ class Whip_WPDismissOption implements Whip_DismissStorage {
 	/**
 	 * Returns the value of the whip_dismissed option.
 	 *
-	 * @return string|int Returns the value of the option or an empty string when not set.
+	 * @return int Returns the value of the option or an empty string when not set.
 	 */
 	public function get() {
 		$dismissedOption = get_option( $this->optionName );
@@ -30,7 +30,7 @@ class Whip_WPDismissOption implements Whip_DismissStorage {
 			return 0;
 		}
 
-		return $dismissedOption;
+		return (int) $dismissedOption;
 	}
 
 }

--- a/src/Whip_WPDismissOption.php
+++ b/src/Whip_WPDismissOption.php
@@ -6,7 +6,7 @@
 class Whip_WPDismissOption implements Whip_DismissStorage {
 
 	/** @var string */
-	protected $optionName = 'whip_dismissed_for_wp_version';
+	protected $optionName = 'whip_dismiss_timestamp';
 
 	/**
 	 * Saves the value to the options.

--- a/src/facades/wordpress.php
+++ b/src/facades/wordpress.php
@@ -12,8 +12,6 @@ if ( ! function_exists( 'whip_wp_check_versions' ) ) {
 			return;
 		}
 
-		global $wp_version;
-
 		$config  = include dirname( __FILE__ ) . '/../configs/default.php';
 		$checker = new Whip_RequirementsChecker( $config );
 
@@ -27,7 +25,7 @@ if ( ! function_exists( 'whip_wp_check_versions' ) ) {
 			return;
 		}
 
-		$dismisser = new Whip_MessageDismisser( $wp_version, new Whip_WPDismissOption() );
+		$dismisser = new Whip_MessageDismisser( time(), new Whip_WPDismissOption() );
 
 		$presenter = new Whip_WPMessagePresenter( $checker->getMostRecentMessage(), $dismisser );
 		$presenter->register_hooks();

--- a/src/facades/wordpress.php
+++ b/src/facades/wordpress.php
@@ -25,7 +25,7 @@ if ( ! function_exists( 'whip_wp_check_versions' ) ) {
 			return;
 		}
 
-		$dismisser = new Whip_MessageDismisser( time(), new Whip_WPDismissOption() );
+		$dismisser = new Whip_MessageDismisser( time(), WEEK_IN_SECONDS * 4, new Whip_WPDismissOption() );
 
 		$presenter = new Whip_WPMessagePresenter( $checker->getMostRecentMessage(), $dismisser );
 		$presenter->register_hooks();

--- a/src/facades/wordpress.php
+++ b/src/facades/wordpress.php
@@ -25,9 +25,12 @@ if ( ! function_exists( 'whip_wp_check_versions' ) ) {
 			return;
 		}
 
-		$dismisser = new Whip_MessageDismisser( time(), WEEK_IN_SECONDS * 4, new Whip_WPDismissOption() );
+		$dismissThreshold = WEEK_IN_SECONDS * 4;
+		$dismissMessage = __( 'Remind me again in 4 weeks.', 'wordpress' );
 
-		$presenter = new Whip_WPMessagePresenter( $checker->getMostRecentMessage(), $dismisser );
+		$dismisser = new Whip_MessageDismisser( time(), $dismissThreshold, new Whip_WPDismissOption() );
+
+		$presenter = new Whip_WPMessagePresenter( $checker->getMostRecentMessage(), $dismisser, $dismissMessage );
 		$presenter->register_hooks();
 	}
 }

--- a/src/interfaces/Whip_DismissStorage.php
+++ b/src/interfaces/Whip_DismissStorage.php
@@ -8,7 +8,7 @@ interface Whip_DismissStorage {
 	/**
 	 * Saves the value.
 	 *
-	 * @param string $dismissedValue The value to save.
+	 * @param int $dismissedValue The value to save.
 	 *
 	 * @return bool True when successful.
 	 */
@@ -17,7 +17,7 @@ interface Whip_DismissStorage {
 	/**
 	 * Returns the value.
 	 *
-	 * @return string|int
+	 * @return int
 	 */
 	public function get();
 

--- a/src/interfaces/Whip_DismissStorage.php
+++ b/src/interfaces/Whip_DismissStorage.php
@@ -8,16 +8,16 @@ interface Whip_DismissStorage {
 	/**
 	 * Saves the value.
 	 *
-	 * @param string $dismissedVersion The value to save.
+	 * @param string $dismissedValue The value to save.
 	 *
 	 * @return bool True when successful.
 	 */
-	public function set( $dismissedVersion );
+	public function set( $dismissedValue );
 
 	/**
 	 * Returns the value.
 	 *
-	 * @return string
+	 * @return string|int
 	 */
 	public function get();
 

--- a/src/interfaces/Whip_DismissStorage.php
+++ b/src/interfaces/Whip_DismissStorage.php
@@ -17,7 +17,7 @@ interface Whip_DismissStorage {
 	/**
 	 * Returns the value.
 	 *
-	 * @return int
+	 * @return int The stored value.
 	 */
 	public function get();
 

--- a/src/presenters/Whip_WPMessagePresenter.php
+++ b/src/presenters/Whip_WPMessagePresenter.php
@@ -5,6 +5,10 @@
  */
 class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 
+	/** @var string The string to show to dismiss the message. */
+	private $dismissMessage;
+
+	/** @var Whip_Message The message to be displayed */
 	private $message;
 
 	/** @var Whip_MessageDismisser */
@@ -13,12 +17,14 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 	/**
 	 * Whip_WPMessagePresenter constructor.
 	 *
-	 * @param Whip_Message          $message The message to use in the presenter.
-	 * @param Whip_MessageDismisser $dismisser Dismisser object.
+	 * @param Whip_Message          $message        The message to use in the presenter.
+	 * @param Whip_MessageDismisser $dismisser      Dismisser object.
+	 * @param string                $dismissMessage The copy to show to dismiss the message.
 	 */
-	public function __construct( Whip_Message $message, Whip_MessageDismisser $dismisser ) {
-	    $this->message   = $message;
-		$this->dismisser = $dismisser;
+	public function __construct( Whip_Message $message, Whip_MessageDismisser $dismisser, $dismissMessage ) {
+		$this->message        = $message;
+		$this->dismisser      = $dismisser;
+		$this->dismissMessage = $dismissMessage;
 	}
 
 	/**
@@ -46,11 +52,10 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 			return;
 		}
 
-		/* translators: 1: is a link to dismiss url 2: closing link tag */
 		$dismissButton = sprintf(
-			__( '%1$sRemind me again in 4 weeks.%2$s', 'wordpress' ),
-			'<a href="' . $dismissListener->getDismissURL() . '">',
-			'</a>'
+			'<a href="%2$s">%1$s</a>',
+			$this->dismissMessage,
+			$dismissListener->getDismissURL()
 		);
 
 		printf( '<div class="error"><p>%1$s</p><p>%2$s</p></div>', $this->kses( $this->message->body() ), $dismissButton );
@@ -66,7 +71,7 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 	public function kses( $message ) {
 		return wp_kses( $message, array(
 			'a'      => array(
-				'href' => true,
+				'href'   => true,
 				'target' => true,
 			),
 			'strong' => true,

--- a/src/presenters/Whip_WPMessagePresenter.php
+++ b/src/presenters/Whip_WPMessagePresenter.php
@@ -48,10 +48,9 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 
 		/* translators: 1: is a link to dismiss url 2: closing link tag */
 		$dismissButton = sprintf(
-			__( '<p>%1$sRemind me again after %3$d weeks.%2$s</p>', 'wordpress' ),
+			__( '<p>%1$sRemind me again after 4 weeks.%2$s</p>', 'wordpress' ),
 			'<a href="' . $dismissListener->getDismissURL() . '">',
-			'</a>',
-			4
+			'</a>'
 		);
 
 		printf( '<div class="error">%1$s<p>%2$s</p></div>', $this->kses( $this->message->body() ), $dismissButton );

--- a/src/presenters/Whip_WPMessagePresenter.php
+++ b/src/presenters/Whip_WPMessagePresenter.php
@@ -48,9 +48,10 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 
 		/* translators: 1: is a link to dismiss url 2: closing link tag */
 		$dismissButton = sprintf(
-			__( '<p>%1$sRemind me again after the next WordPress release.%2$s</p>', 'wordpress' ),
+			__( '<p>%1$sRemind me again after %3$d weeks.%2$s</p>', 'wordpress' ),
 			'<a href="' . $dismissListener->getDismissURL() . '">',
-			'</a>'
+			'</a>',
+			4
 		);
 
 		printf( '<div class="error">%1$s<p>%2$s</p></div>', $this->kses( $this->message->body() ), $dismissButton );

--- a/src/presenters/Whip_WPMessagePresenter.php
+++ b/src/presenters/Whip_WPMessagePresenter.php
@@ -48,12 +48,12 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 
 		/* translators: 1: is a link to dismiss url 2: closing link tag */
 		$dismissButton = sprintf(
-			__( '<p>%1$sRemind me again after 4 weeks.%2$s</p>', 'wordpress' ),
+			__( '%1$sRemind me again in 4 weeks.%2$s', 'wordpress' ),
 			'<a href="' . $dismissListener->getDismissURL() . '">',
 			'</a>'
 		);
 
-		printf( '<div class="error">%1$s<p>%2$s</p></div>', $this->kses( $this->message->body() ), $dismissButton );
+		printf( '<div class="error"><p>%1$s</p><p>%2$s</p></div>', $this->kses( $this->message->body() ), $dismissButton );
 	}
 
 	/**

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -13,7 +13,7 @@ class Whip_DismissStorageMock implements Whip_DismissStorage {
 	/**
 	 * Saves the value.
 	 *
-	 * @param string $dismissedValue The value to save.
+	 * @param int $dismissedValue The value to save.
 	 *
 	 * @return boolean
 	 */
@@ -26,7 +26,7 @@ class Whip_DismissStorageMock implements Whip_DismissStorage {
 	/**
 	 * Returns the value.
 	 *
-	 * @return string|int
+	 * @return int
 	 */
 	public function get() {
 		return $this->dismissed;

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -60,7 +60,6 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @covers Whip_MessageDismisser::__construct()
 	 * @covers Whip_MessageDismisser::isDismissed()
-	 * @covers Whip_MessageDismisser::getThreshold()
 	 */
 	public function testIsDismissibleWithVersions( $savedTime, $currentTime, $expected ) {
 		$storage = new Whip_DismissStorageMock();

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -78,8 +78,9 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 	public function versionNumbersProvider() {
 		return array(
 			array( strtotime( "-2weeks" ), time(), true ),
-			array( strtotime( "-4weeks" ), time(), false ),
+			array( strtotime( "-4weeks" ), time(), true ),
 			array( strtotime( "-6weeks" ), time(), false ),
+			array( time(), time(), true ),
 		);
 	}
 

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -42,7 +42,7 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 	public function testDismiss() {
 		$currentTime = time();
 		$storage     = new Whip_DismissStorageMock();
-		$dismisser = new Whip_MessageDismisser( $currentTime, $storage );
+		$dismisser   = new Whip_MessageDismisser( $currentTime, WEEK_IN_SECONDS * 4, $storage );
 
 		$this->assertEquals( 0, $storage->get() );
 
@@ -65,7 +65,7 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 	public function testIsDismissibleWithVersions( $savedTime, $currentTime, $expected ) {
 		$storage = new Whip_DismissStorageMock();
 		$storage->set( $savedTime );
-		$dismisser = new Whip_MessageDismisser( $currentTime, $storage );
+		$dismisser = new Whip_MessageDismisser( $currentTime, WEEK_IN_SECONDS * 4, $storage );
 
 		$this->assertEquals( $expected, $dismisser->isDismissed() );
 	}

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -80,7 +80,6 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 			array( strtotime( "-2weeks" ), time(), true ),
 			array( strtotime( "-4weeks" ), time(), false ),
 			array( strtotime( "-6weeks" ), time(), false ),
-			array( time(), time(), true ),
 		);
 	}
 


### PR DESCRIPTION
Instead of checking on major WP Version change we are now showing the notice every 4 weeks.

Test instructions
* Get this branch into WordPress SEO
* Change the threshold [dependency value in dismisser declaration](https://github.com/Yoast/whip/compare/42-show-notice-every-4-weeks?expand=1#diff-f04337685746b3069189252b50ae45dcR28) into a value that is easier to test. For example: 2 minutes.

Fixes #42 