### PR TITLE
CS: improve regex

### DIFF
--- a/src/Whip_VersionRequirement.php
+++ b/src/Whip_VersionRequirement.php
@@ -79,14 +79,16 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	 */
 	public static function fromCompareString( $component, $comparisonString ) {
 
-		$matcher = '(' .
-		               '(>=?)' . // Matches >= and >.
-		               '|' .
-		               '(<=?)' . // Matches <= and <.
-		           ')' .
-		           '([^>=<\s]+)'; // Matches anything except >, <, =, and whitespace.
+		$matcher = '`
+			(
+				(>=?)   # Matches >= and >.
+				|
+				(<=?)   # Matches <= and <.
+			)
+			([^>=<\s]+) # Matches anything except >, <, =, and whitespace.
+		`x';
 
-		if ( ! preg_match( '#' . $matcher . '#', $comparisonString, $match ) ) {
+		if ( ! preg_match( $matcher, $comparisonString, $match ) ) {
 			throw new Whip_InvalidVersionComparisonString( $comparisonString );
 		}
 

--- a/src/Whip_VersionRequirement.php
+++ b/src/Whip_VersionRequirement.php
@@ -81,9 +81,9 @@ class Whip_VersionRequirement implements Whip_Requirement {
 
 		$matcher = '`
 			(
-				(>=?)   # Matches >= and >.
+				>=?     # Matches >= and >.
 				|
-				(<=?)   # Matches <= and <.
+				<=?     # Matches <= and <.
 			)
 			([^>=<\s]+) # Matches anything except >, <, =, and whitespace.
 		`x';
@@ -92,7 +92,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 			throw new Whip_InvalidVersionComparisonString( $comparisonString );
 		}
 
-		$version  = $match[4];
+		$version  = $match[2];
 		$operator = $match[1];
 
 		return new Whip_VersionRequirement( $component, $version, $operator );


### PR DESCRIPTION
### CS: fix regex layout

Using the `x` modifier allows for using comments within a regex itself removing the need for the concatenation previously used.
The `x` modifier ignores all whitespace within the regex, allowing for a nice layout as well.
To facilitate this, I've moved the regex delimiters up into the regex string, so the modifier and the regex stay together.

Refs:
* http://php.net/manual/en/reference.pcre.pattern.modifiers.php

### CS: minor regex efficiency improvement

No need to remember sub-matches which are not being used anyway (previously match 2 and 3). The parentheses were in this case also not needed for grouping, so removing them was the simplest fix.


### Testing this

There are already unit tests in place which cover this method comprehensively, so if I did things right, those should still pass. Sic: *and they pass as expected*