### PR TITLE
CS/XSS: correctly escape output

### DIFF
--- a/src/presenters/Whip_WPMessagePresenter.php
+++ b/src/presenters/Whip_WPMessagePresenter.php
@@ -49,11 +49,17 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 
 		$dismissButton = sprintf(
 			'<a href="%2$s">%1$s</a>',
-			$this->dismissMessage,
-			$dismissListener->getDismissURL()
+			esc_html( $this->dismissMessage ),
+			esc_url( $dismissListener->getDismissURL() )
 		);
 
-		printf( '<div class="error"><p>%1$s</p><p>%2$s</p></div>', $this->kses( $this->message->body() ), $dismissButton );
+		// phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped -- output correctly escaped directly above and in the `kses()` method.
+		printf(
+			'<div class="error"><p>%1$s</p><p>%2$s</p></div>',
+			$this->kses( $this->message->body() ),
+			$dismissButton
+		);
+		// phpcs:enable
 	}
 
 	/**


### PR DESCRIPTION
Minor output escaping fixes.

Also whitelists one output call for which all the parts are correctly escaped before being passed to the output call. This whitelisting will take effect once YoastCS 0.5 has been activated.