### PR TITLE
CS: function naming consistency

### DIFF
--- a/src/facades/wordpress.php
+++ b/src/facades/wordpress.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'whip_wp_check_versions' ) ) {
 		
 		// Prevent duplicate notices across multiple implementing plugins.
 		if ( ! has_action( 'whip_register_hooks' ) ) {
-			add_action( 'whip_register_hooks', array( $presenter, 'register_hooks' ) );
+			add_action( 'whip_register_hooks', array( $presenter, 'registerHooks' ) );
 		}
 
 		/**

--- a/src/presenters/Whip_WPMessagePresenter.php
+++ b/src/presenters/Whip_WPMessagePresenter.php
@@ -32,7 +32,7 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 	 *
 	 * This is a separate function so you can control when the hooks are registered.
 	 */
-	public function register_hooks() {
+	public function registerHooks() {
 		add_action( 'admin_notices', array( $this, 'renderMessage' ) );
 	}
 


### PR DESCRIPTION
Historically, this library uses `camelCaps` for function names instead of the WP convention of using `snake_case`.

There is no need to change this, we just need to allow for it and fix up the one exception to the rules (and allow for one more, but that will be handled via the PHPCS ruleset).

As this involves a `public` method, this *can* be considered a BC-break. However, the reason for the method to be `public` is that it is hooked in via `add_action()`, not because it is a method which external parties are expected to call on, so I expect the BC-break to be theoretical and not to have any impact in practical terms.