### PR TITLE
Security: add Roave/SecurityAdvisories dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "A WordPress package to nudge users to upgrade their software versions (starting with PHP)",
     "type": "library",
     "require-dev": {
-        "phpunit/phpunit": "^3.6.12 | ^4.5 | ^5.7"
+        "phpunit/phpunit": "^3.6.12 | ^4.5 | ^5.7",
+        "roave/security-advisories": "dev-master"
     },
     "license": "GPL-3.0-or-later",
     "authors": [


### PR DESCRIPTION
This dependency will prevent packages with known security issues from being installed through Composer.

The package will always have to be at `dev-master` to make sure that the latest security information available will be used.

Refs:
* https://github.com/Roave/SecurityAdvisories
* https://www.bleepingcomputer.com/news/security/php-community-takes-steps-to-stop-installation-of-libraries-with-unpatched-bugs/
* https://websec.io/2018/03/10/Package-Protection-Roave-SecurityAdvisories.html