### PR TITLE
I18n: various fixes

### DIFF
--- a/src/Whip_RequirementsChecker.php
+++ b/src/Whip_RequirementsChecker.php
@@ -26,7 +26,7 @@ class Whip_RequirementsChecker {
 	 * @param array  $configuration The configuration to check.
 	 * @param string $textdomain    The text domain to use for translations.
 	 */
-	public function __construct( $configuration = array(), $textdomain = 'wordpress' ) {
+	public function __construct( $configuration = array(), $textdomain = 'default' ) {
 		$this->requirements    = array();
 		$this->configuration   = new Whip_Configuration( $configuration );
 		$this->messageMananger = new Whip_MessagesManager();

--- a/src/facades/wordpress.php
+++ b/src/facades/wordpress.php
@@ -31,7 +31,7 @@ if ( ! function_exists( 'whip_wp_check_versions' ) ) {
 		}
 
 		$dismissThreshold = ( WEEK_IN_SECONDS * 4 );
-		$dismissMessage   = __( 'Remind me again in 4 weeks.', 'wordpress' );
+		$dismissMessage   = __( 'Remind me again in 4 weeks.', 'default' );
 
 		$dismisser = new Whip_MessageDismisser( time(), $dismissThreshold, new Whip_WPDismissOption() );
 

--- a/src/messages/Whip_HostMessage.php
+++ b/src/messages/Whip_HostMessage.php
@@ -56,6 +56,7 @@ class Whip_HostMessage implements Whip_Message {
 	 * @return string The message title.
 	 */
 	public function title() {
+		/* translators: 1: name. */
 		return sprintf( __( 'A message from %1$s', $this->textdomain ), Whip_Host::name() );
 	}
 }

--- a/src/messages/Whip_UpgradePhpMessage.php
+++ b/src/messages/Whip_UpgradePhpMessage.php
@@ -40,6 +40,7 @@ class Whip_UpgradePhpMessage implements Whip_Message {
 		$message[] = Whip_MessageFormatter::strongParagraph( __( 'To which version should I update?', $textdomain ) ) . '<br />';
 		$message[] = Whip_MessageFormatter::paragraph(
 			sprintf(
+				/* translators: 1: link open tag; 2: link close tag. */
 				__( 'You should update your PHP version to either 5.6 or to 7.0 or 7.1. On a normal WordPress site, switching to PHP 5.6 should never cause issues. We would however actually recommend you switch to PHP7. There are some plugins that are not ready for PHP7 though, so do some testing first. We have an article on how to test whether that\'s an option for you %1$shere%2$s. PHP7 is much faster than PHP 5.6. It\'s also the only PHP version still in active development and therefore the better option for your site in the long run.', $textdomain ),
 				'<a href="https://yoa.st/wg" target="_blank">',
 				'</a>'
@@ -58,22 +59,22 @@ class Whip_UpgradePhpMessage implements Whip_Message {
 		if ( function_exists( 'apply_filters' ) && apply_filters( Whip_Host::HOSTING_PAGE_FILTER_KEY, false ) ) {
 			$message[] = Whip_MessageFormatter::paragraph(
 				sprintf(
-					__( 'If you cannot upgrade your PHP version yourself, you can send an email to your host. We have %1$sexamples here%2$s. If they don\'t want to upgrade your PHP version, we would suggest you switch hosts. Have a look at one of the recommended %3$sWordPress hosting partners%4$s.', $textdomain ),
+					/* translators: 1: link open tag; 2: link close tag; 3: link open tag. */
+					__( 'If you cannot upgrade your PHP version yourself, you can send an email to your host. We have %1$sexamples here%2$s. If they don\'t want to upgrade your PHP version, we would suggest you switch hosts. Have a look at one of the recommended %3$sWordPress hosting partners%2$s.', $textdomain ),
 					'<a href="https://yoa.st/wh" target="_blank">',
 					'</a>',
-					sprintf( '<a href="%1$s" target="_blank">', esc_url( $hostingPageUrl ) ),
-					'</a>'
+					sprintf( '<a href="%1$s" target="_blank">', esc_url( $hostingPageUrl ) )
 				)
 			);
 		}
 		else {
 			$message[] = Whip_MessageFormatter::paragraph(
 				sprintf(
-					__( 'If you cannot upgrade your PHP version yourself, you can send an email to your host. We have %1$sexamples here%2$s. If they don\'t want to upgrade your PHP version, we would suggest you switch hosts. Have a look at one of our recommended %3$sWordPress hosting partners%4$s, they\'ve all been vetted by our Yoast support team and provide all the features a modern host should provide.', $textdomain ),
+					/* translators: 1: link open tag; 2: link close tag; 3: link open tag. */
+					__( 'If you cannot upgrade your PHP version yourself, you can send an email to your host. We have %1$sexamples here%2$s. If they don\'t want to upgrade your PHP version, we would suggest you switch hosts. Have a look at one of our recommended %3$sWordPress hosting partners%2$s, they\'ve all been vetted by our Yoast support team and provide all the features a modern host should provide.', $textdomain ),
 					'<a href="https://yoa.st/wh" target="_blank">',
 					'</a>',
-					sprintf( '<a href="%1$s" target="_blank">', esc_url( $hostingPageUrl ) ),
-					'</a>'
+					sprintf( '<a href="%1$s" target="_blank">', esc_url( $hostingPageUrl ) )
 				)
 			);
 		}

--- a/src/messages/Whip_UpgradePhpMessage.php
+++ b/src/messages/Whip_UpgradePhpMessage.php
@@ -35,7 +35,7 @@ class Whip_UpgradePhpMessage implements Whip_Message {
 		$message = array();
 
 		$message[] = Whip_MessageFormatter::strongParagraph( __( 'Your site could be faster and more secure with a newer PHP version.', $textdomain ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::paragraph( __( 'Hey, we\'ve noticed that you\'re running an outdated version of PHP. PHP is the programming language that WordPress and Yoast SEO are built on. The version that is currently used for your site is no longer supported. Newer versions of PHP are both faster and more secure. In fact, your version of PHP no longer receives security updates, which is why we\'re sending you to this notice.', $textdomain ) );
+		$message[] = Whip_MessageFormatter::paragraph( __( 'Hey, we\'ve noticed that you\'re running an outdated version of PHP. PHP is the programming language that WordPress and all it\'s plugins and themes are built on. The version that is currently used for your site is no longer supported. Newer versions of PHP are both faster and more secure. In fact, your version of PHP no longer receives security updates, which is why we\'re sending you to this notice.', $textdomain ) );
 		$message[] = Whip_MessageFormatter::paragraph( __( 'Hosts have the ability to update your PHP version, but sometimes they don\'t dare to do that because they\'re afraid they\'ll break your site.', $textdomain ) );
 		$message[] = Whip_MessageFormatter::strongParagraph( __( 'To which version should I update?', $textdomain ) ) . '<br />';
 		$message[] = Whip_MessageFormatter::paragraph(
@@ -71,7 +71,7 @@ class Whip_UpgradePhpMessage implements Whip_Message {
 			$message[] = Whip_MessageFormatter::paragraph(
 				sprintf(
 					/* translators: 1: link open tag; 2: link close tag; 3: link open tag. */
-					__( 'If you cannot upgrade your PHP version yourself, you can send an email to your host. We have %1$sexamples here%2$s. If they don\'t want to upgrade your PHP version, we would suggest you switch hosts. Have a look at one of our recommended %3$sWordPress hosting partners%2$s, they\'ve all been vetted by our Yoast support team and provide all the features a modern host should provide.', $textdomain ),
+					__( 'If you cannot upgrade your PHP version yourself, you can send an email to your host. We have %1$sexamples here%2$s. If they don\'t want to upgrade your PHP version, we would suggest you switch hosts. Have a look at one of our recommended %3$sWordPress hosting partners%2$s, they\'ve all been vetted by the Yoast support team and provide all the features a modern host should provide.', $textdomain ),
 					'<a href="https://yoa.st/wh" target="_blank">',
 					'</a>',
 					sprintf( '<a href="%1$s" target="_blank">', esc_url( $hostingPageUrl ) )

--- a/src/messages/Whip_UpgradePhpMessage.php
+++ b/src/messages/Whip_UpgradePhpMessage.php
@@ -35,7 +35,7 @@ class Whip_UpgradePhpMessage implements Whip_Message {
 		$message = array();
 
 		$message[] = Whip_MessageFormatter::strongParagraph( __( 'Your site could be faster and more secure with a newer PHP version.', $textdomain ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::paragraph( __( 'Hey, we\'ve noticed that you\'re running an outdated version of PHP. PHP is the programming language that WordPress and all it\'s plugins and themes are built on. The version that is currently used for your site is no longer supported. Newer versions of PHP are both faster and more secure. In fact, your version of PHP no longer receives security updates, which is why we\'re sending you to this notice.', $textdomain ) );
+		$message[] = Whip_MessageFormatter::paragraph( __( 'Hey, we\'ve noticed that you\'re running an outdated version of PHP. PHP is the programming language that WordPress and all its plugins and themes are built on. The version that is currently used for your site is no longer supported. Newer versions of PHP are both faster and more secure. In fact, your version of PHP no longer receives security updates, which is why we\'re sending you to this notice.', $textdomain ) );
 		$message[] = Whip_MessageFormatter::paragraph( __( 'Hosts have the ability to update your PHP version, but sometimes they don\'t dare to do that because they\'re afraid they\'ll break your site.', $textdomain ) );
 		$message[] = Whip_MessageFormatter::strongParagraph( __( 'To which version should I update?', $textdomain ) ) . '<br />';
 		$message[] = Whip_MessageFormatter::paragraph(


### PR DESCRIPTION
### I18n: fix incorrect text-domain

The text-domain for WordPress itself is `default`, not `wordpress`.

### I18n: add missing translators comments

Includes minor efficiency fix for `sprintf()`: when using numbered replacements, you can use the same replacement twice, so no need to have `'</a>'` twice in the replacement list.

### I18n: Make the text slightly more plugin agnostic

AFAIK WHIP is intended to also be usable by other (non-Yoast) plugins/themes.
There were currently two phrases which made this awkward.

This PR changes those.

For the first phrase, I've chosen to change `WordPress and Yoast SEO` to `WordPress and all it's plugins and themes`. This incidentally fixes issue #35. /cc @afercia 
If it is preferred that `Yoast SEO` not be removed, I would suggest the following:
* Move the name out of the text string and put it back in using `sprintf()`.
* Make the name filterable to allow other plugins to pass in their plugin name.
    - Potentially, it could even be turned into an array which could be passed into the string using `implode()` to allow for a number of plugins to be mentioned.

For the second phrase, just changing the `our` in `vetted by our Yoast support team` to `the` improves the re-usability.

Fixes #35

