### PR TITLE
InvalidType Exception: fix the various calls to this Exception

### DIFF
--- a/src/Whip_Configuration.php
+++ b/src/Whip_Configuration.php
@@ -24,7 +24,7 @@ class Whip_Configuration {
 	 */
 	public function __construct( $configuration = array() ) {
 		if ( ! is_array( $configuration ) ) {
-			throw new Whip_InvalidType( 'Configuration', gettype( $configuration ), 'array' );
+			throw new Whip_InvalidType( 'Configuration', $configuration, 'array' );
 		}
 
 		$this->configuration = $configuration;

--- a/src/Whip_VersionRequirement.php
+++ b/src/Whip_VersionRequirement.php
@@ -115,7 +115,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 		}
 
 		if ( ! is_string( $component ) ) {
-			throw new Whip_InvalidType( 'Component', 'string', $component );
+			throw new Whip_InvalidType( 'Component', $component, 'string' );
 		}
 
 		if ( empty( $version ) ) {
@@ -123,7 +123,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 		}
 
 		if ( ! is_string( $version ) ) {
-			throw new Whip_InvalidType( 'Version', 'string', $version );
+			throw new Whip_InvalidType( 'Version', $version, 'string' );
 		}
 
 		if ( empty( $operator ) ) {
@@ -131,7 +131,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 		}
 
 		if ( ! is_string( $operator ) ) {
-			throw new Whip_InvalidType( 'Operator', 'string', $operator );
+			throw new Whip_InvalidType( 'Operator', $operator, 'string' );
 		}
 
 		if ( ! in_array( $operator, array( '=', '==', '===', '<', '>', '<=', '>=' ), true ) ) {

--- a/src/exceptions/Whip_InvalidType.php
+++ b/src/exceptions/Whip_InvalidType.php
@@ -13,9 +13,9 @@ class Whip_InvalidType extends Exception {
 	/**
 	 * InvalidType constructor.
 	 *
-	 * @param string $property
-	 * @param string $value
-	 * @param string $expectedType
+	 * @param string $property     Property name.
+	 * @param string $value        Property value.
+	 * @param string $expectedType Expected property type.
 	 */
 	public function __construct( $property, $value, $expectedType ) {
 		parent::__construct( sprintf( '%s should be of type %s. Found %s.', $property, $expectedType, gettype( $value ) ) );

--- a/src/messages/Whip_BasicMessage.php
+++ b/src/messages/Whip_BasicMessage.php
@@ -42,7 +42,7 @@ class Whip_BasicMessage implements Whip_Message {
 		}
 
 		if ( ! is_string( $body ) ) {
-			throw new Whip_InvalidType( 'Message body', 'string', $body );
+			throw new Whip_InvalidType( 'Message body', $body, 'string' );
 		}
 	}
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -25,6 +25,7 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @expectedException Whip_InvalidType
+	 * @expectedExceptionMessage Message body should be of type string. Found integer.
 	 */
 	public function testMessageMustBeString() {
 		new Whip_BasicMessage( 123 );

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -33,6 +33,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @expectedException Whip_InvalidType
+	 * @expectedExceptionMessage Component should be of type string. Found integer.
 	 */
 	public function testComponentMustBeString() {
 		new Whip_VersionRequirement( 123, '5.2' );
@@ -40,6 +41,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @expectedException Whip_InvalidType
+	 * @expectedExceptionMessage Version should be of type string. Found integer.
 	 */
 	public function testVersionMustBeString() {
 		new Whip_VersionRequirement( 'php', 123 );
@@ -54,6 +56,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @expectedException Whip_InvalidType
+	 * @expectedExceptionMessage Operator should be of type string. Found integer.
 	 */
 	public function testOperatorMustBeString() {
 		new Whip_VersionRequirement( 'php', '5.2', 6 );


### PR DESCRIPTION
#### Bug description:
* The parameter order for most calls to this Exception was incorrect.
* Where it was correct, a `gettype()` was used, while this is already done in the exception class itself, leading to incorrect results.

#### PR notes:
* Includes improvement to the parameter documentation of the Exception constructor.
* Includes unit tests proving the bug and safeguarding against it in the future.