### PR TITLE
InvalidOperatorType Exception: improve documentation, duplicate code and unit test

### DIFF
--- a/src/Whip_VersionRequirement.php
+++ b/src/Whip_VersionRequirement.php
@@ -134,8 +134,9 @@ class Whip_VersionRequirement implements Whip_Requirement {
 			throw new Whip_InvalidType( 'Operator', 'string', $operator );
 		}
 
-		if ( ! in_array( $operator, array( '=', '==', '===', '<', '>', '<=', '>=' ), true ) ) {
-			throw new Whip_InvalidOperatorType( $operator );
+		$validOperators = array( '=', '==', '===', '<', '>', '<=', '>=' );
+		if ( ! in_array( $operator, $validOperators, true ) ) {
+			throw new Whip_InvalidOperatorType( $operator, $validOperators );
 		}
 	}
 }

--- a/src/exceptions/Whip_InvalidOperatorType.php
+++ b/src/exceptions/Whip_InvalidOperatorType.php
@@ -11,23 +11,17 @@
 class Whip_InvalidOperatorType extends Exception {
 
 	/**
-	 * Valid comparison operators as strings.
-	 *
-	 * @var array
-	 */
-	private $validOperators = array( '=', '==', '===', '<', '>', '<=', '>=' );
-
-	/**
 	 * InvalidOperatorType constructor.
 	 *
-	 * @param string $value Invalid operator.
+	 * @param string $value          Invalid operator.
+	 * @param array  $validOperators Valid operators.
 	 */
-	public function __construct( $value ) {
+	public function __construct( $value, $validOperators = array( '=', '==', '===', '<', '>', '<=', '>=' ) ) {
 		parent::__construct(
 			sprintf(
 				'Invalid operator of %s used. Please use one of the following operators: %s',
 				$value,
-				implode( ', ', $this->validOperators )
+				implode( ', ', $validOperators )
 			)
 		);
 	}

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -61,6 +61,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @expectedException Whip_InvalidOperatorType
+	 * @expectedExceptionMessage Invalid operator of -> used. Please use one of the following operators: =, ==, ===, <, >, <=, >=
 	 */
 	public function testOperatorMustBeValid() {
 		new Whip_VersionRequirement( 'php', '5.2', '->' );


### PR DESCRIPTION
The `$validOperators` were defined in two places, making the chance of these two arrays getting out of sync large and lowering maintainability.

I've now:
* Removed the `$validOperators` property in the `Whip_InvalidOperatorType` class in favour of adding a new parameter to the constructor.
* The one call to the Exception will now pass the operators against which it validates.
* The message text of the Exception is now unit tested.