### PR TITLE
Documentation: various fixes

### DIFF
--- a/src/Whip_Configuration.php
+++ b/src/Whip_Configuration.php
@@ -11,6 +11,8 @@
 class Whip_Configuration {
 
 	/**
+	 * The configuration to use.
+	 *
 	 * @var array
 	 */
 	private $configuration;
@@ -20,7 +22,7 @@ class Whip_Configuration {
 	 *
 	 * @param array $configuration The configuration to use.
 	 *
-	 * @throws Whip_InvalidType
+	 * @throws Whip_InvalidType When the $configuration parameter is not of the expected type.
 	 */
 	public function __construct( $configuration = array() ) {
 		if ( ! is_array( $configuration ) ) {

--- a/src/Whip_Host.php
+++ b/src/Whip_Host.php
@@ -9,7 +9,19 @@
  * Represents a host.
  */
 class Whip_Host {
+
+	/**
+	 * Key to an environment variable which should be set to the name of the host.
+	 *
+	 * @var string
+	 */
 	const HOST_NAME_KEY = 'WHIP_NAME_OF_HOST';
+
+	/**
+	 * Filter name for the filter which allows for pointing to the WP hosting page instead of the Yoast version.
+	 *
+	 * @var string
+	 */
 	const HOSTING_PAGE_FILTER_KEY = 'whip_hosting_page_url_wordpress';
 
 	/**
@@ -24,7 +36,8 @@ class Whip_Host {
 	}
 
 	/**
-	 * Filters the name if we are in a WordPress context. In a non-WordPress content this function just returns the passed name.
+	 * Filters the name if we are in a WordPress context.
+	 * In a non-WordPress content this function just returns the passed name.
 	 *
 	 * @param string $name The current name of the host.
 	 * @returns string The filtered name of the host.
@@ -51,7 +64,8 @@ class Whip_Host {
 	}
 
 	/**
-	 * Filters the message if we are in a WordPress context. In a non-WordPress content this function just returns the passed message.
+	 * Filters the message if we are in a WordPress context.
+	 * In a non-WordPress content this function just returns the passed message.
 	 *
 	 * @param string $messageKey The key used for the environment variable.
 	 * @param string $message    The current message from the host.
@@ -78,7 +92,8 @@ class Whip_Host {
 	}
 
 	/**
-	 * Filters the hosting page url if we are in a WordPress context. In a non-WordPress context this function just returns a link to the Yoast hosting page.
+	 * Filters the hosting page url if we are in a WordPress context.
+	 * In a non-WordPress context this function just returns a link to the Yoast hosting page.
 	 *
 	 * @param string $url The previous URL.
 	 * @returns string The new URL to the hosting overview page.

--- a/src/Whip_MessageDismisser.php
+++ b/src/Whip_MessageDismisser.php
@@ -11,16 +11,22 @@
 class Whip_MessageDismisser {
 
 	/**
+	 * Storage object to manage the dismissal state.
+	 *
 	 * @var Whip_DismissStorage
 	 */
 	protected $storage;
 
 	/**
+	 * The current time.
+	 *
 	 * @var string
 	 */
 	protected $currentTime;
 
 	/**
+	 * The number of seconds the message will be dismissed.
+	 *
 	 * @var int
 	 */
 	protected $threshold;

--- a/src/Whip_RequirementsChecker.php
+++ b/src/Whip_RequirementsChecker.php
@@ -11,11 +11,15 @@
 class Whip_RequirementsChecker {
 
 	/**
+	 * Requirements the environment should comply with.
+	 *
 	 * @var array
 	 */
 	private $requirements;
 
 	/**
+	 * The text domain to use for translations.
+	 *
 	 * @var string
 	 */
 	private $textdomain;

--- a/src/Whip_VersionRequirement.php
+++ b/src/Whip_VersionRequirement.php
@@ -47,7 +47,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	}
 
 	/**
-	 * Get the component name defined for the requirement.
+	 * Retrieves the component name defined for the requirement.
 	 *
 	 * @return string The component name.
 	 */
@@ -56,7 +56,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	}
 
 	/**
-	 * Get the components version defined for the requirement.
+	 * Gets the components version defined for the requirement.
 	 *
 	 * @return string
 	 */
@@ -65,7 +65,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	}
 
 	/**
-	 * Get the operator to use when comparing version numbers.
+	 * Gets the operator to use when comparing version numbers.
 	 *
 	 * @return string The comparison operator.
 	 */
@@ -74,7 +74,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	}
 
 	/**
-	 * Create a new version requirement from a comparison string.
+	 * Creates a new version requirement from a comparison string.
 	 *
 	 * @throws Whip_InvalidVersionComparisonString When an invalid version comparison string is passed.
 	 *
@@ -105,7 +105,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	}
 
 	/**
-	 * Validate the parameters passed to the requirement.
+	 * Validates the parameters passed to the requirement.
 	 *
 	 * @param string $component The component name.
 	 * @param string $version   The component version.

--- a/src/Whip_VersionRequirement.php
+++ b/src/Whip_VersionRequirement.php
@@ -11,16 +11,22 @@
 class Whip_VersionRequirement implements Whip_Requirement {
 
 	/**
+	 * The component name.
+	 *
 	 * @var string
 	 */
 	private $component;
 
 	/**
+	 * The component version.
+	 *
 	 * @var string
 	 */
 	private $version;
 
 	/**
+	 * The operator to use when comparing version.
+	 *
 	 * @var string
 	 */
 	private $operator;
@@ -28,9 +34,9 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	/**
 	 * Whip_Requirement constructor.
 	 *
-	 * @param string $component
-	 * @param string $version
-	 * @param string $operator
+	 * @param string $component The component name.
+	 * @param string $version   The component version.
+	 * @param string $operator  The operator to use when comparing version.
 	 */
 	public function __construct( $component, $version, $operator = '=' ) {
 		$this->validateParameters( $component, $version, $operator );
@@ -41,7 +47,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	}
 
 	/**
-	 * Gets the component name defined for the requirement.
+	 * Get the component name defined for the requirement.
 	 *
 	 * @return string The component name.
 	 */
@@ -50,7 +56,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	}
 
 	/**
-	 * Gets the components version defined for the requirement.
+	 * Get the components version defined for the requirement.
 	 *
 	 * @return string
 	 */
@@ -59,7 +65,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	}
 
 	/**
-	 * Returns the operator to use when comparing version numbers.
+	 * Get the operator to use when comparing version numbers.
 	 *
 	 * @return string The comparison operator.
 	 */
@@ -68,7 +74,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	}
 
 	/**
-	 * Creates a new version requirement from a comparison string.
+	 * Create a new version requirement from a comparison string.
 	 *
 	 * @throws Whip_InvalidVersionComparisonString When an invalid version comparison string is passed.
 	 *
@@ -99,15 +105,15 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	}
 
 	/**
-	 * Validates the parameters passed to the requirement.
+	 * Validate the parameters passed to the requirement.
 	 *
 	 * @param string $component The component name.
 	 * @param string $version   The component version.
 	 * @param string $operator  The operator to use when comparing version.
 	 *
-	 * @throws Whip_EmptyProperty
-	 * @throws Whip_InvalidOperatorType
-	 * @throws Whip_InvalidType
+	 * @throws Whip_EmptyProperty       When any of the parameters is empty.
+	 * @throws Whip_InvalidOperatorType When the $operator parameter is invalid.
+	 * @throws Whip_InvalidType         When any of the parameters is not of the expected type.
 	 */
 	private function validateParameters( $component, $version, $operator ) {
 		if ( empty( $component ) ) {

--- a/src/Whip_WPDismissOption.php
+++ b/src/Whip_WPDismissOption.php
@@ -11,6 +11,8 @@
 class Whip_WPDismissOption implements Whip_DismissStorage {
 
 	/**
+	 * WordPress option name.
+	 *
 	 * @var string
 	 */
 	protected $optionName = 'whip_dismiss_timestamp';

--- a/src/Whip_WPMessageDismissListener.php
+++ b/src/Whip_WPMessageDismissListener.php
@@ -10,9 +10,16 @@
  */
 class Whip_WPMessageDismissListener implements Whip_Listener {
 
+	/**
+	 * The name of the dismiss action expected to be passed via $_GET.
+	 *
+	 * @var string
+	 */
 	const ACTION_NAME = 'whip_dismiss';
 
 	/**
+	 * The object for dismissing a message.
+	 *
 	 * @var Whip_MessageDismisser
 	 */
 	protected $dismisser;

--- a/src/exceptions/Whip_InvalidVersionComparisonString.php
+++ b/src/exceptions/Whip_InvalidVersionComparisonString.php
@@ -11,6 +11,8 @@
 class Whip_InvalidVersionComparisonString extends Exception {
 
 	/**
+	 * InvalidVersionComparisonString constructor.
+	 *
 	 * @param string $value The passed version comparison string.
 	 */
 	public function __construct( $value ) {

--- a/src/interfaces/Whip_Message.php
+++ b/src/interfaces/Whip_Message.php
@@ -11,7 +11,7 @@
 interface Whip_Message {
 
 	/**
-	 * Retrieve the message body.
+	 * Retrieves the message body.
 	 *
 	 * @return string Message.
 	 */

--- a/src/interfaces/Whip_Message.php
+++ b/src/interfaces/Whip_Message.php
@@ -10,5 +10,10 @@
  */
 interface Whip_Message {
 
+	/**
+	 * Retrieve the message body.
+	 *
+	 * @return string Message.
+	 */
 	public function body();
 }

--- a/src/interfaces/Whip_Requirement.php
+++ b/src/interfaces/Whip_Requirement.php
@@ -11,7 +11,7 @@
 interface Whip_Requirement {
 
 	/**
-	 * Get the component name defined for the requirement.
+	 * Retrieves the component name defined for the requirement.
 	 *
 	 * @return string The component name.
 	 */

--- a/src/interfaces/Whip_Requirement.php
+++ b/src/interfaces/Whip_Requirement.php
@@ -10,5 +10,10 @@
  */
 interface Whip_Requirement {
 
+	/**
+	 * Get the component name defined for the requirement.
+	 *
+	 * @return string The component name.
+	 */
 	public function component();
 }

--- a/src/messages/Whip_BasicMessage.php
+++ b/src/messages/Whip_BasicMessage.php
@@ -29,7 +29,7 @@ class Whip_BasicMessage implements Whip_Message {
 	}
 
 	/**
-	 * Retrieve the message body.
+	 * Retrieves the message body.
 	 *
 	 * @return string Message.
 	 */
@@ -38,7 +38,7 @@ class Whip_BasicMessage implements Whip_Message {
 	}
 
 	/**
-	 * Validate the parameters passed to the constructor of this class.
+	 * Validates the parameters passed to the constructor of this class.
 	 *
 	 * @param string $body Message body.
 	 *

--- a/src/messages/Whip_BasicMessage.php
+++ b/src/messages/Whip_BasicMessage.php
@@ -11,6 +11,8 @@
 class Whip_BasicMessage implements Whip_Message {
 
 	/**
+	 * Message body.
+	 *
 	 * @var string
 	 */
 	private $body;
@@ -18,10 +20,7 @@ class Whip_BasicMessage implements Whip_Message {
 	/**
 	 * Whip_Message constructor.
 	 *
-	 * @param string $body
-	 *
-	 * @throws Whip_EmptyProperty
-	 * @throws Whip_InvalidType
+	 * @param string $body Message body.
 	 */
 	public function __construct( $body ) {
 		$this->validateParameters( $body );
@@ -30,12 +29,22 @@ class Whip_BasicMessage implements Whip_Message {
 	}
 
 	/**
-	 * @return string
+	 * Retrieve the message body.
+	 *
+	 * @return string Message.
 	 */
 	public function body() {
 		return $this->body;
 	}
 
+	/**
+	 * Validate the parameters passed to the constructor of this class.
+	 *
+	 * @param string $body Message body.
+	 *
+	 * @throws Whip_EmptyProperty When the $body parameter is empty.
+	 * @throws Whip_InvalidType   When the $body parameter is not of the expected type.
+	 */
 	private function validateParameters( $body ) {
 		if ( empty( $body ) ) {
 			throw new Whip_EmptyProperty( 'Message body' );

--- a/src/messages/Whip_HostMessage.php
+++ b/src/messages/Whip_HostMessage.php
@@ -41,7 +41,7 @@ class Whip_HostMessage implements Whip_Message {
 	}
 
 	/**
-	 * Renders the message body.
+	 * Retrieves the message body.
 	 *
 	 * @return string The message body.
 	 */

--- a/src/messages/Whip_HostMessage.php
+++ b/src/messages/Whip_HostMessage.php
@@ -11,11 +11,15 @@
 class Whip_HostMessage implements Whip_Message {
 
 	/**
+	 * Text domain to use for translations.
+	 *
 	 * @var string
 	 */
 	private $textdomain;
 
 	/**
+	 * The environment key to use to retrieve the message from.
+	 *
 	 * @var string
 	 */
 	private $messageKey;

--- a/src/messages/Whip_InvalidVersionRequirementMessage.php
+++ b/src/messages/Whip_InvalidVersionRequirementMessage.php
@@ -36,7 +36,7 @@ class Whip_InvalidVersionRequirementMessage implements Whip_Message {
 	}
 
 	/**
-	 * Retrieve the message body.
+	 * Retrieves the message body.
 	 *
 	 * @return string Message.
 	 */

--- a/src/messages/Whip_InvalidVersionRequirementMessage.php
+++ b/src/messages/Whip_InvalidVersionRequirementMessage.php
@@ -11,6 +11,8 @@
 class Whip_InvalidVersionRequirementMessage implements Whip_Message {
 
 	/**
+	 * Object containing the version requirement for a component.
+	 *
 	 * @var Whip_VersionRequirement
 	 */
 	private $requirement;
@@ -25,8 +27,8 @@ class Whip_InvalidVersionRequirementMessage implements Whip_Message {
 	/**
 	 * Whip_InvalidVersionRequirementMessage constructor.
 	 *
-	 * @param Whip_VersionRequirement $requirement
-	 * @param string|int              $detected    Detected version requirement or -1 if found.
+	 * @param Whip_VersionRequirement $requirement Object containing the version requirement for a component.
+	 * @param string|int              $detected    Detected version requirement or -1 if not found.
 	 */
 	public function __construct( Whip_VersionRequirement $requirement, $detected ) {
 		$this->requirement = $requirement;
@@ -34,7 +36,9 @@ class Whip_InvalidVersionRequirementMessage implements Whip_Message {
 	}
 
 	/**
-	 * @return string
+	 * Retrieve the message body.
+	 *
+	 * @return string Message.
 	 */
 	public function body() {
 		return sprintf(

--- a/src/messages/Whip_NullMessage.php
+++ b/src/messages/Whip_NullMessage.php
@@ -11,7 +11,7 @@
 class Whip_NullMessage implements Whip_Message {
 
 	/**
-	 * Retrieve the message body.
+	 * Retrieves the message body.
 	 *
 	 * @return string Message.
 	 */

--- a/src/messages/Whip_NullMessage.php
+++ b/src/messages/Whip_NullMessage.php
@@ -11,7 +11,9 @@
 class Whip_NullMessage implements Whip_Message {
 
 	/**
-	 * @return string
+	 * Retrieve the message body.
+	 *
+	 * @return string Message.
 	 */
 	public function body() {
 		return '';

--- a/src/messages/Whip_UpgradePhpMessage.php
+++ b/src/messages/Whip_UpgradePhpMessage.php
@@ -27,7 +27,7 @@ class Whip_UpgradePhpMessage implements Whip_Message {
 	}
 
 	/**
-	 * Composes the body of the message to display.
+	 * Retrieves the message body to display.
 	 *
 	 * @return string The message to display.
 	 */

--- a/src/messages/Whip_UpgradePhpMessage.php
+++ b/src/messages/Whip_UpgradePhpMessage.php
@@ -11,6 +11,8 @@
 class Whip_UpgradePhpMessage implements Whip_Message {
 
 	/**
+	 * The text domain to use for the translations.
+	 *
 	 * @var string
 	 */
 	private $textdomain;

--- a/src/presenters/Whip_WPMessagePresenter.php
+++ b/src/presenters/Whip_WPMessagePresenter.php
@@ -25,6 +25,8 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 	private $message;
 
 	/**
+	 * Dismisser object.
+	 *
 	 * @var Whip_MessageDismisser
 	 */
 	private $dismisser;


### PR DESCRIPTION
* Add short descriptions to various functions, properties and function parameters.
* Add missing function docblocks.
* Move some `@throws` tags which were placed with the wrong function.
* Add short descriptions to all `@throws` tags.
* Fix incorrect documentation
    - `Whip_InvalidVersionRequirementMessage::__construct()` `$detected` description: `if found` versus `if not found`