### PR TITLE
Travis: don't install PHPUnit when not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,8 @@ before_install:
 
 install:
 - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.3.29; fi
-- composer selfupdate --no-interaction
-- composer install --prefer-dist --no-interaction
 - if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then composer remove --dev phpunit/phpunit; fi
+- composer install --prefer-dist --no-interaction
 - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local --unset; fi
 
 script:


### PR DESCRIPTION
Having the line to `remove phpunit` underneath the `install` command, makes that it has no effect at the time of the initial install, moving it up fixes this.

Also removed the `selfupdate` command in line with the Travis script in other plugins/modules.