### PR TITLE
CS: start using YoastCS 0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor/
 /composer.lock
+.phpcs.xml
+phpcs.xml

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -83,4 +83,17 @@
 	</rule>
 
 
+	<!--
+	#############################################################################
+	TEMPORARY ADJUSTMENTS
+	Adjustments which should be removed once the associated issue has been resolved.
+	#############################################################################
+	-->
+
+	<!-- Textdomain is passed in dynamically which will not work correctly with gettext().
+		 Ticket: https://github.com/Yoast/whip/issues/2 -->
+	<rule ref="WordPress.WP.I18n.NonSingularStringLiteralDomain">
+		<type>warning</type>
+	</rule>
+
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -71,4 +71,16 @@
 	<!-- Set the minimum supported WP version. This is used by several sniffs. -->
 	<config name="minimum_supported_wp_version" value="3.0"/>
 
+	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<!-- Provide the prefixes to look for. -->
+			<property name="prefixes" type="array" value="whip"/>
+		</properties>
+
+		<!-- Valid usage: For testing purposes, allow non-prefixed globals. -->
+		<exclude-pattern>/tests/doubles/WPCoreFunctionsMock\.php$</exclude-pattern>
+	</rule>
+
+
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -33,14 +33,29 @@
 	-->
 
 	<rule ref="Yoast">
-		<!-- Historically, this library has used camelCaps not snakecase for variable names. -->
+		<!-- Historically, this library has used camelCaps not snakecase for variable and function names. -->
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+		<exclude name="WordPress.NamingConventions.ValidFunctionName"/>
 	</rule>
 
 	<!-- Check that variable names are in camelCaps. -->
 	<rule ref="Squiz.NamingConventions.ValidVariableName">
 		<!-- Private properties should, however, *not* start with an underscore. -->
 		<exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>
+	</rule>
+
+	<!-- Check that function and method names are in camelCaps. -->
+	<rule ref="Generic.NamingConventions.CamelCapsFunctionName">
+		<properties>
+			<!-- Allow for two adjacent capital letters for acronyms. -->
+			<property name="strict" value="false"/>
+		</properties>
+		
+		<!-- Exclude WordPress example function. -->
+		<exclude-pattern>/src/facades/wordpress\.php$</exclude-pattern>
+
+		<!-- Exclude mocks of WP Core functions which comply with the WP function name rules instead. -->
+		<exclude-pattern>/tests/doubles/WpCoreFunctionsMock\.php$</exclude-pattern>
 	</rule>
 
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -111,4 +111,19 @@
 		<exclude-pattern>/src/Whip_Host\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Tests should be documented too.
+		 Ticket: https://github.com/Yoast/whip/issues/66 -->
+	<rule ref="Generic.Commenting.DocComment.MissingShort">
+		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+	</rule>
+	<rule ref="Generic.Commenting.DocComment.SpacingBeforeTags">
+		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment.Missing">
+		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
+		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -105,4 +105,10 @@
 		<exclude-pattern>/tests/doubles/WPCoreFunctionsMock\.php$</exclude-pattern>
 	</rule>
 
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound">
+		<!-- These hook setups should be reviewed.
+			 Ticket: https://github.com/Yoast/whip/issues/67 -->
+		<exclude-pattern>/src/Whip_Host\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -96,4 +96,13 @@
 		<type>warning</type>
 	</rule>
 
+	<rule ref="WordPress.WP.I18n.NonSingularStringLiteralText">
+		<!-- False positive. This has already been fixed in WPCS.
+			 The fix will be included in WPCS 1.0.0.
+			 Once this repo moves up to using WPCS 1.0.0, this exclusion can be removed.
+			 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1267
+		-->
+		<exclude-pattern>/tests/doubles/WPCoreFunctionsMock\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -32,7 +32,16 @@
 	#############################################################################
 	-->
 
-	<rule ref="Yoast"/>
+	<rule ref="Yoast">
+		<!-- Historically, this library has used camelCaps not snakecase for variable names. -->
+		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+	</rule>
+
+	<!-- Check that variable names are in camelCaps. -->
+	<rule ref="Squiz.NamingConventions.ValidVariableName">
+		<!-- Private properties should, however, *not* start with an underscore. -->
+		<exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>
+	</rule>
 
 
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<ruleset name="Yoast WHIP">
+	<description>Yoast WHIP rules for PHP_CodeSniffer</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	#############################################################################
+	-->
+
+	<file>.</file>
+
+	<exclude-pattern>vendor/*</exclude-pattern>
+
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Show progress, show the error codes for each message (source). -->
+	<arg value="ps"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultanously. -->
+	<arg name="parallel" value="8"/>
+
+
+	<!--
+	#############################################################################
+	USE THE YoastCS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="Yoast"/>
+
+
+</ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -62,4 +62,13 @@
 	</rule>
 
 
+	<!--
+	#############################################################################
+	SNIFF SPECIFIC CONFIGURATION
+	#############################################################################
+	-->
+
+	<!-- Set the minimum supported WP version. This is used by several sniffs. -->
+	<config name="minimum_supported_wp_version" value="3.0"/>
+
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -36,6 +36,9 @@
 		<!-- Historically, this library has used camelCaps not snakecase for variable and function names. -->
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
 		<exclude name="WordPress.NamingConventions.ValidFunctionName"/>
+
+		<!-- Historically, this library uses camelCaps file names. -->
+		<exclude name="Yoast.Files.FileName"/>
 	</rule>
 
 	<!-- Check that variable names are in camelCaps. -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
   fast_finish: true
   include:
     - php: 7.2
+      env: PHPCS=1
     - php: 5.2
       dist: precise
     - php: 5.3
@@ -44,3 +45,4 @@ script:
 - find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
 - if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then phpunit; else ./vendor/bin/phpunit; fi
 - if [[ "$TRAVIS_PHP_VERSION" != "5.2" ]]; then composer validate --no-check-all; fi
+- if [[ $PHPCS == "1" ]]; then vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ before_install:
 
 install:
 - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.3.29; fi
-- if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then composer remove --dev phpunit/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then composer remove --dev yoast/yoastcs dealerdirect/phpcodesniffer-composer-installer; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then composer remove --dev phpunit/phpunit; fi
 - composer install --prefer-dist --no-interaction
 - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local --unset; fi
 

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,6 @@
     "name": "yoast/whip",
     "description": "A WordPress package to nudge users to upgrade their software versions (starting with PHP)",
     "type": "library",
-    "require-dev": {
-        "phpunit/phpunit": "^3.6.12 | ^4.5 | ^5.7",
-        "roave/security-advisories": "dev-master"
-    },
     "license": "GPL-3.0-or-later",
     "authors": [
         {
@@ -23,6 +19,12 @@
     },
     "require": {
         "xrstf/composer-php52": "^1.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^3.6.12 | ^4.5 | ^5.7",
+        "roave/security-advisories": "dev-master",
+        "yoast/yoastcs": "~0.5.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

This PR moves this repo onto [YoastCS](https://github.com/Yoast/yoastcs) 0.5.

Please see the individual commits for details and complete documentation about the changes.

* Fixed the YoastCS dependency to the `0.5.*` range.
* Added a ruleset file.
* Excluded existing function and vairable name rules and added different ones as this library uses camelCaps.
* Added configuration for various WPCS sniffs to increase their usefulness.
    See [WPCS Customizable sniff properties](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties) for detailed information.
* Added a few temporary exclusions:
    - One for a WPCS bug which will be fixed in the WPCS `1.0.0` release;
    - Three for actual issues which need to be fixed. For each of these a ticket has been created if one didn't exist yet. See #2, #66, #66.
        Most of these issues have been excluded from being reported, though for one, the `error` has been downgraded to a `warning`.

## Test instructions

This PR can be tested by following these steps:
* Run `vendor/bin/phpcs` without arguments to see that the library code is clean (other than the above mentioned warnings).
