### PR TITLE
CS: Update PHPCS ruleset for PHPCS 3.3.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -75,7 +75,9 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Provide the prefixes to look for. -->
-			<property name="prefixes" type="array" value="whip"/>
+			<property name="prefixes" type="array">
+				<element value="whip"/>
+			</property>
 		</properties>
 
 		<!-- Valid usage: For testing purposes, allow non-prefixed globals. -->


### PR DESCRIPTION
Use the new property array format. The old format is still supported for now, but will be removed in PHPCS 4.0.

See: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.3.0

As this repo does not have a `composer.lock` file, no other changes are needed AFAICS.