### PR TITLE
PHPCS: Update to use YoastCS 1.0 / WPCS 1.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -98,15 +98,6 @@
 		<type>warning</type>
 	</rule>
 
-	<rule ref="WordPress.WP.I18n.NonSingularStringLiteralText">
-		<!-- False positive. This has already been fixed in WPCS.
-			 The fix will be included in WPCS 1.0.0.
-			 Once this repo moves up to using WPCS 1.0.0, this exclusion can be removed.
-			 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1267
-		-->
-		<exclude-pattern>/tests/doubles/WPCoreFunctionsMock\.php$</exclude-pattern>
-	</rule>
-
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound">
 		<!-- These hook setups should be reviewed.
 			 Ticket: https://github.com/Yoast/whip/issues/67 -->
@@ -116,9 +107,6 @@
 	<!-- Tests should be documented too.
 		 Ticket: https://github.com/Yoast/whip/issues/66 -->
 	<rule ref="Generic.Commenting.DocComment.MissingShort">
-		<exclude-pattern>/tests/*\.php$</exclude-pattern>
-	</rule>
-	<rule ref="Generic.Commenting.DocComment.SpacingBeforeTags">
 		<exclude-pattern>/tests/*\.php$</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.FunctionComment.Missing">

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "^3.6.12 | ^4.5 | ^5.7",
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "~0.5.0",
+        "yoast/yoastcs": "^1.0.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
     },
     "scripts": {

--- a/src/Whip_RequirementsChecker.php
+++ b/src/Whip_RequirementsChecker.php
@@ -153,5 +153,4 @@ class Whip_RequirementsChecker {
 	public function getMostRecentMessage() {
 		return $this->messageMananger->getLatestMessage();
 	}
-
 }

--- a/src/Whip_WPDismissOption.php
+++ b/src/Whip_WPDismissOption.php
@@ -41,5 +41,4 @@ class Whip_WPDismissOption implements Whip_DismissStorage {
 
 		return (int) $dismissedOption;
 	}
-
 }

--- a/src/Whip_WPMessageDismissListener.php
+++ b/src/Whip_WPMessageDismissListener.php
@@ -59,5 +59,4 @@ class Whip_WPMessageDismissListener implements Whip_Listener {
 			wp_create_nonce( self::ACTION_NAME )
 		);
 	}
-
 }

--- a/src/facades/wordpress.php
+++ b/src/facades/wordpress.php
@@ -48,6 +48,5 @@ if ( ! function_exists( 'whip_wp_check_versions' ) ) {
 		 * @param \Whip_WPMessagePresenter $presenter Message presenter instance.
 		 */
 		do_action( 'whip_register_hooks', $presenter );
-
 	}
 }

--- a/src/interfaces/Whip_DismissStorage.php
+++ b/src/interfaces/Whip_DismissStorage.php
@@ -25,5 +25,4 @@ interface Whip_DismissStorage {
 	 * @return int The stored value.
 	 */
 	public function get();
-
 }

--- a/src/interfaces/Whip_Listener.php
+++ b/src/interfaces/Whip_Listener.php
@@ -16,5 +16,4 @@ interface Whip_Listener {
 	 * @return void
 	 */
 	public function listen();
-
 }

--- a/src/messages/Whip_UpgradePhpMessage.php
+++ b/src/messages/Whip_UpgradePhpMessage.php
@@ -83,5 +83,4 @@ class Whip_UpgradePhpMessage implements Whip_Message {
 
 		return implode( $message, "\n" );
 	}
-
 }

--- a/src/presenters/Whip_WPMessagePresenter.php
+++ b/src/presenters/Whip_WPMessagePresenter.php
@@ -70,7 +70,7 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 			esc_url( $dismissListener->getDismissURL() )
 		);
 
-		// phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped -- output correctly escaped directly above and in the `kses()` method.
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- output correctly escaped directly above and in the `kses()` method.
 		printf(
 			'<div class="error"><p>%1$s</p><p>%2$s</p></div>',
 			$this->kses( $this->message->body() ),

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -9,6 +9,7 @@
  * Configuration unit tests.
  */
 class ConfigurationTest extends PHPUnit_Framework_TestCase {
+
 	/**
 	 * @expectedException Whip_InvalidType
 	 */

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -64,5 +64,4 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 			array( time(), time(), true ),
 		);
 	}
-
 }

--- a/tests/MessagesManagerTest.php
+++ b/tests/MessagesManagerTest.php
@@ -18,6 +18,5 @@ class MessagesManagerTest extends PHPUnit_Framework_TestCase {
 		$GLOBALS['whip_messages'][] = 'I am a test message';
 
 		$this->assertTrue( $manager->hasMessages() );
-
 	}
 }


### PR DESCRIPTION
### Composer: require YoastCS 1.0.0

### PHPCS: update ruleset and annotations for YoastCS/WPCS 1.0.0

* Remove an exclusion for a false positive which was fixed in WPCS 1.0.0.
* Remove an exclusion for a bug in PHPCS which was fixed in PHPCS 3.3.1.
* The `EscapeOutput` sniff has been moved to the `Security` category in WPCS 1.0.0.

### CS: minor whitespace fixes to comply with YoastCS 1.0.0 