### PR TITLE
Added documentation to the WHIP unit tests 

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -104,16 +104,4 @@
 		<exclude-pattern>/src/Whip_Host\.php$</exclude-pattern>
 	</rule>
 
-	<!-- Tests should be documented too.
-		 Ticket: https://github.com/Yoast/whip/issues/66 -->
-	<rule ref="Generic.Commenting.DocComment.MissingShort">
-		<exclude-pattern>/tests/*\.php$</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.FunctionComment.Missing">
-		<exclude-pattern>/tests/*\.php$</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
-		<exclude-pattern>/tests/*\.php$</exclude-pattern>
-	</rule>
-
 </ruleset>

--- a/src/Whip_RequirementsChecker.php
+++ b/src/Whip_RequirementsChecker.php
@@ -29,12 +29,14 @@ class Whip_RequirementsChecker {
 	 *
 	 * @param array  $configuration The configuration to check.
 	 * @param string $textdomain    The text domain to use for translations.
+	 *
+	 * @throws Whip_InvalidType When the $configuration parameter is not of the expected type.
 	 */
 	public function __construct( $configuration = array(), $textdomain = 'default' ) {
-		$this->requirements    = array();
-		$this->configuration   = new Whip_Configuration( $configuration );
-		$this->messageMananger = new Whip_MessagesManager();
-		$this->textdomain      = $textdomain;
+		$this->requirements   = array();
+		$this->configuration  = new Whip_Configuration( $configuration );
+		$this->messageManager = new Whip_MessagesManager();
+		$this->textdomain     = $textdomain;
 	}
 
 	/**
@@ -128,10 +130,10 @@ class Whip_RequirementsChecker {
 	private function addMissingRequirementMessage( Whip_Requirement $requirement ) {
 		switch ( $requirement->component() ) {
 			case 'php':
-				$this->messageMananger->addMessage( new Whip_UpgradePhpMessage( $this->textdomain ) );
+				$this->messageManager->addMessage( new Whip_UpgradePhpMessage( $this->textdomain ) );
 				break;
 			default:
-				$this->messageMananger->addMessage( new Whip_InvalidVersionRequirementMessage( $requirement, $this->configuration->configuredVersion( $requirement ) ) );
+				$this->messageManager->addMessage( new Whip_InvalidVersionRequirementMessage( $requirement, $this->configuration->configuredVersion( $requirement ) ) );
 				break;
 		}
 	}
@@ -142,7 +144,7 @@ class Whip_RequirementsChecker {
 	 * @return bool Whether or not there are messages to display.
 	 */
 	public function hasMessages() {
-		return $this->messageMananger->hasMessages();
+		return $this->messageManager->hasMessages();
 	}
 
 	/**
@@ -151,6 +153,6 @@ class Whip_RequirementsChecker {
 	 * @return Whip_Message The latest message.
 	 */
 	public function getMostRecentMessage() {
-		return $this->messageMananger->getLatestMessage();
+		return $this->messageManager->getLatestMessage();
 	}
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -11,12 +11,19 @@
 class ConfigurationTest extends PHPUnit_Framework_TestCase {
 
 	/**
+	 * Tests the creation of a Whip_Configuration with invalid input.
+	 *
 	 * @expectedException Whip_InvalidType
 	 */
 	public function testItThrowsAnErrorIfAFaultyConfigurationIsPassed() {
 		$configuration = new Whip_Configuration( 'Invalid configuration' );
 	}
 
+	/**
+	 * Tests if Whip_Configuration correctly returns -1 when passed an unknown requirement.
+	 *
+	 * @covers WPSEO_Indexable_Service::get_indexable()
+	 */
 	public function testItReturnsANegativeNumberIfRequirementCannotBeFound() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );
 		$requirement   = $this->getMockBuilder( 'Whip_Requirement' )
@@ -31,6 +38,9 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( -1, $configuration->configuredVersion( $requirement ) );
 	}
 
+	/**
+	 * Tests if Whip_Configuration correctly returns the version number when passed a valid requirement.
+	 */
 	public function testItReturnsAnEntryIfRequirementIsFound() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );
 		$requirement   = $this->getMockBuilder( 'Whip_Requirement' )
@@ -45,6 +55,9 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( '5.6', $configuration->configuredVersion( $requirement ) );
 	}
 
+	/**
+	 * Tests if hasRequirementConfigures correctly returns true/false when called with valid/invalid values.
+	 */
 	public function testIfRequirementIsConfigured() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );
 		$requirement   = $this->getMockBuilder( 'Whip_Requirement' )

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -13,7 +13,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests the creation of a Whip_Configuration with invalid input.
 	 *
-	 * @expectedException Whip_InvalidType
+	 * @expectedException Whip_InvalidType()
 	 */
 	public function testItThrowsAnErrorIfAFaultyConfigurationIsPassed() {
 		$configuration = new Whip_Configuration( 'Invalid configuration' );
@@ -22,7 +22,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if Whip_Configuration correctly returns -1 when passed an unknown requirement.
 	 *
-	 * @covers WPSEO_Indexable_Service::get_indexable()
+	 * @covers Whip_Configuration::configuredVersion()
 	 */
 	public function testItReturnsANegativeNumberIfRequirementCannotBeFound() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );
@@ -40,6 +40,8 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests if Whip_Configuration correctly returns the version number when passed a valid requirement.
+	 *
+	 * @covers Whip_Configuration::configuredVersion()
 	 */
 	public function testItReturnsAnEntryIfRequirementIsFound() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );
@@ -57,6 +59,8 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests if hasRequirementConfigures correctly returns true/false when called with valid/invalid values.
+	 *
+	 * @covers Whip_Configuration::hasRequirementConfigured()
 	 */
 	public function testIfRequirementIsConfigured() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -13,7 +13,8 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests the creation of a Whip_Configuration with invalid input.
 	 *
-	 * @expectedException Whip_InvalidType()
+	 * @expectedException Whip_InvalidType
+	 * @expectedExceptionMessage Configuration should be of type array. Found string.
 	 */
 	public function testItThrowsAnErrorIfAFaultyConfigurationIsPassed() {
 		$configuration = new Whip_Configuration( 'Invalid configuration' );

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -11,7 +11,7 @@
 class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * Instantiates our test class
+	 * Instantiates our test class.
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -11,7 +11,7 @@
 class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * Instantiate our test class
+	 * Instantiates our test class
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -10,6 +10,9 @@
  */
 class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 
+	/**
+	 * Instantiate our test class
+	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
@@ -18,6 +21,8 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests if Whip_MessageDismisser correctly updates Whip_DismissStorage.
+	 *
 	 * @covers Whip_MessageDismisser::__construct()
 	 * @covers Whip_MessageDismisser::dismiss()
 	 */
@@ -34,6 +39,8 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests if isDismissed correctly sets the version.
+	 *
 	 * @dataProvider versionNumbersProvider
 	 *
 	 * @param int  $savedTime   The saved time.

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -10,6 +10,9 @@
  */
 class MessageTest extends PHPUnit_Framework_TestCase {
 
+	/**
+	 * Tests if Whip_BasicMessage correctly handles a string for its body argument.
+	 */
 	public function testMessageHasBody() {
 		$message = new Whip_BasicMessage( 'This is a message' );
 
@@ -17,6 +20,8 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests if an Exception is correctly thrown when an empty string is passed as argument.
+	 *
 	 * @expectedException Whip_EmptyProperty
 	 * @expectedExceptionMessage Message body cannot be empty.
 	 */
@@ -25,6 +30,8 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests if an Exception is correctly thrown when an invalid type is passed as argument.
+	 *
 	 * @expectedException Whip_InvalidType
 	 * @expectedExceptionMessage Message body should be of type string. Found integer.
 	 */

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -12,6 +12,8 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests if Whip_BasicMessage correctly handles a string for its body argument.
+	 *
+	 * @covers Whip_BasicMessage::body()
 	 */
 	public function testMessageHasBody() {
 		$message = new Whip_BasicMessage( 'This is a message' );
@@ -24,6 +26,8 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @expectedException Whip_EmptyProperty
 	 * @expectedExceptionMessage Message body cannot be empty.
+	 *
+	 * @covers Whip_BasicMessage::validateParameters()
 	 */
 	public function testMessageCannotBeEmpty() {
 		new Whip_BasicMessage( '' );
@@ -34,6 +38,8 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @expectedException Whip_InvalidType
 	 * @expectedExceptionMessage Message body should be of type string. Found integer.
+	 *
+	 * @covers Whip_BasicMessage::validateParameters()
 	 */
 	public function testMessageMustBeString() {
 		new Whip_BasicMessage( 123 );

--- a/tests/MessagesManagerTest.php
+++ b/tests/MessagesManagerTest.php
@@ -10,6 +10,9 @@
  */
 class MessagesManagerTest extends PHPUnit_Framework_TestCase {
 
+	/**
+	 * Creates a MessagesManager, tests if it returns false without message, true when given a message.
+	 */
 	public function testHasMessages() {
 		$manager = new Whip_MessagesManager();
 

--- a/tests/MessagesManagerTest.php
+++ b/tests/MessagesManagerTest.php
@@ -11,7 +11,9 @@
 class MessagesManagerTest extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * Creates a MessagesManager, tests if it returns false without message, true when given a message.
+	 * Creates a MessagesManager, calls hasMessages and tests if it returns false without a message, true when given a message.
+	 *
+	 * @covers Whip_MessagesManager::hasMessages()
 	 */
 	public function testHasMessages() {
 		$manager = new Whip_MessagesManager();

--- a/tests/RequirementsCheckerTest.php
+++ b/tests/RequirementsCheckerTest.php
@@ -11,7 +11,7 @@
 class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * Instantiate our test class
+	 * Set up the class by requiring the WP Core functions mock.
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
@@ -21,6 +21,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests if Whip_RequirementsChecker is successfully created when given valid arguments.
+	 *
+	 * @covers Whip_RequirementsChecker::addRequirement()
+	 * @covers Whip_RequirementsChecker::totalRequirements()
 	 */
 	public function testItReceivesAUsableRequirementObject() {
 		$checker = new Whip_RequirementsChecker();
@@ -33,6 +36,7 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if Whip_RequirementsChecker throws an error when passed an invalid requirement.
 	 *
+	 * @covers Whip_RequirementsChecker::addRequirement()
 	 * @requires PHP 7
 	 */
 	public function testItThrowsAnTypeErrorWhenInvalidRequirementIsPassed() {
@@ -55,6 +59,8 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests if Whip_RequirementsChecker throws an error when passed an invalid requirement.
+	 *
+	 * @covers Whip_RequirementsChecker::addRequirement()
 	 */
 	public function testItThrowsAnTypeErrorWhenInvalidRequirementIsPassedInPHP5() {
 		if ( version_compare( phpversion(), 7.0, '>=' ) ) {
@@ -76,6 +82,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests if Whip_RequirementsChecker only saves unique components.
+	 *
+	 * @covers Whip_RequirementsChecker::addRequirement()
+	 * @covers Whip_RequirementsChecker::totalRequirements()
 	 */
 	public function testItOnlyContainsUniqueComponents() {
 		$checker = new Whip_RequirementsChecker();
@@ -93,6 +102,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests if Whip_RequirementsChecker::requirementExistsForComponent correctly returns true for existing components.
+	 *
+	 * @covers Whip_RequirementsChecker::addRequirement()
+	 * @covers Whip_RequirementsChecker::requirementExistsForComponent()
 	 */
 	public function testIfRequirementExists() {
 		$checker = new Whip_RequirementsChecker();
@@ -105,19 +117,12 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * If the requirement is fulfilled, there should be no message.
-	 */
-	public function testCheckIfRequirementIsFulfilled() {
-		$checker = new Whip_RequirementsChecker( array( 'php' => phpversion() ) );
-
-		$checker->addRequirement( new Whip_VersionRequirement( 'php', '5.2' ) );
-		$checker->check();
-
-		$this->assertEmpty( $checker->getMostRecentMessage()->body() );
-	}
-
-	/**
-	 * Creates a situation in which the php requirement is not met; a php upgrade message is created and successfully transferred to a variable.
+	 * Tests a situation in which the php requirement is not met; a php upgrade message is created and successfully transferred to a variable.
+	 *
+	 * @covers Whip_RequirementsChecker::addRequirement()
+	 * @covers Whip_RequirementsChecker::check()
+	 * @covers Whip_RequirementsChecker::hasMessages()
+	 * @covers Whip_RequirementsChecker::getMostRecentMessage()
 	 */
 	public function testCheckIfPHPRequirementIsNotFulfilled() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => 4 ) );
@@ -137,7 +142,28 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Creates a situation in which the mysql requirement is not met; a invalid version message is created and successfully transferred to a variable.
+	 * Tests if there no message when the requirement is fulfilled.
+	 *
+	 * @covers Whip_RequirementsChecker::addRequirement()
+	 * @covers Whip_RequirementsChecker::check()
+	 * @covers Whip_RequirementsChecker::getMostRecentMessage()
+	 */
+	public function testCheckIfRequirementIsFulfilled() {
+		$checker = new Whip_RequirementsChecker( array( 'php' => phpversion() ) );
+
+		$checker->addRequirement( new Whip_VersionRequirement( 'php', '5.2' ) );
+		$checker->check();
+
+		$this->assertEmpty( $checker->getMostRecentMessage()->body() );
+	}
+
+	/**
+	 * Tests a situation in which the mysql requirement is not met; an invalid version message is created and successfully transferred to a variable.
+	 *
+	 * @covers Whip_RequirementsChecker::addRequirement()
+	 * @covers Whip_RequirementsChecker::check()
+	 * @covers Whip_RequirementsChecker::getMostRecentMessage()
+	 * @covers Whip_RequirementsChecker::hasMessages()
 	 */
 	public function testCheckIfRequirementIsNotFulfilled() {
 		$checker = new Whip_RequirementsChecker( array( 'mysql' => 4 ) );
@@ -158,6 +184,10 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests if a specific comparison with a non-default operator is correctly handled.
+	 *
+	 * @covers Whip_RequirementsChecker::addRequirement()
+	 * @covers Whip_RequirementsChecker::check()
+	 * @covers Whip_RequirementsChecker::hasMessages()
 	 */
 	public function testCheckIfRequirementIsFulfilledWithSpecificComparison() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => 4 ) );
@@ -170,6 +200,10 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests if a specific comparison with a non-default operator is correctly handled.
+	 *
+	 * @covers Whip_RequirementsChecker::addRequirement()
+	 * @covers Whip_RequirementsChecker::check()
+	 * @covers Whip_RequirementsChecker::hasMessages()
 	 */
 	public function testCheckIfRequirementIsNotFulfilledWithSpecificComparison() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => 4 ) );

--- a/tests/RequirementsCheckerTest.php
+++ b/tests/RequirementsCheckerTest.php
@@ -10,12 +10,18 @@
  */
 class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 
+	/**
+	 * Instantiate our test class
+	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
 		require_once dirname( __FILE__ ) . '/doubles/WPCoreFunctionsMock.php';
 	}
 
+	/**
+	 * Tests if Whip_RequirementsChecker is successfully created when given valid arguments.
+	 */
 	public function testItReceivesAUsableRequirementObject() {
 		$checker = new Whip_RequirementsChecker();
 		$checker->addRequirement( new Whip_VersionRequirement( 'php', '5.2' ) );
@@ -25,6 +31,8 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests if Whip_RequirementsChecker throws an error when passed an invalid requirement.
+	 *
 	 * @requires PHP 7
 	 */
 	public function testItThrowsAnTypeErrorWhenInvalidRequirementIsPassed() {
@@ -45,6 +53,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $exceptionCaught );
 	}
 
+	/**
+	 * Tests if Whip_RequirementsChecker throws an error when passed an invalid requirement.
+	 */
 	public function testItThrowsAnTypeErrorWhenInvalidRequirementIsPassedInPHP5() {
 		if ( version_compare( phpversion(), 7.0, '>=' ) ) {
 			$this->markTestSkipped();
@@ -63,6 +74,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $exceptionCaught );
 	}
 
+	/**
+	 * Tests if Whip_RequirementsChecker only saves unique components.
+	 */
 	public function testItOnlyContainsUniqueComponents() {
 		$checker = new Whip_RequirementsChecker();
 
@@ -77,6 +91,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 2, $checker->totalRequirements() );
 	}
 
+	/**
+	 * Tests if Whip_RequirementsChecker::requirementExistsForComponent correctly returns true for existing components.
+	 */
 	public function testIfRequirementExists() {
 		$checker = new Whip_RequirementsChecker();
 
@@ -87,6 +104,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse( $checker->requirementExistsForComponent( 'mongodb' ) );
 	}
 
+	/**
+	 * If the requirement is fulfilled, there should be no message.
+	 */
 	public function testCheckIfRequirementIsFulfilled() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => phpversion() ) );
 
@@ -96,6 +116,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEmpty( $checker->getMostRecentMessage()->body() );
 	}
 
+	/**
+	 * Creates a situation in which the php requirement is not met; a php upgrade message is created and successfully transferred to a variable.
+	 */
 	public function testCheckIfPHPRequirementIsNotFulfilled() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => 4 ) );
 
@@ -113,6 +136,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf( 'Whip_UpgradePhpMessage', $recentMessage );
 	}
 
+	/**
+	 * Creates a situation in which the mysql requirement is not met; a invalid version message is created and successfully transferred to a variable.
+	 */
 	public function testCheckIfRequirementIsNotFulfilled() {
 		$checker = new Whip_RequirementsChecker( array( 'mysql' => 4 ) );
 
@@ -130,6 +156,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 		$this->assertStringStartsWith( 'Invalid version detected', $recentMessage->body() );
 	}
 
+	/**
+	 * Tests if a specific comparison with a non-default operator is correctly handled.
+	 */
 	public function testCheckIfRequirementIsFulfilledWithSpecificComparison() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => 4 ) );
 
@@ -139,6 +168,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse( $checker->hasMessages() );
 	}
 
+	/**
+	 * Tests if a specific comparison with a non-default operator is correctly handled.
+	 */
 	public function testCheckIfRequirementIsNotFulfilledWithSpecificComparison() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => 4 ) );
 

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -12,6 +12,9 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Creates a new Whip_VersionRequirement with component php and version 5.2 and tests if this is correctly created.
+	 *
+	 * @covers Whip_VersionRequirement::component()
+	 * @covers Whip_VersionRequirement::version()
 	 */
 	public function testNameAndVersionAreNotEmpty() {
 		$requirement = new Whip_VersionRequirement( 'php', '5.2' );
@@ -23,6 +26,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with an empty component.
 	 *
+	 * @covers Whip_VersionRequirement::validateParameters()
+	 *
 	 * @expectedException Whip_EmptyProperty
 	 * @expectedExceptionMessage Component cannot be empty.
 	 */
@@ -32,6 +37,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with an empty version.
+	 *
+	 * @covers Whip_VersionRequirement::validateParameters()
 	 *
 	 * @expectedException Whip_EmptyProperty
 	 * @expectedExceptionMessage Version cannot be empty.
@@ -43,6 +50,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with a false type for a component.
 	 *
+	 * @covers Whip_VersionRequirement::validateParameters()
+	 *
 	 * @expectedException Whip_InvalidType
 	 * @expectedExceptionMessage Component should be of type string. Found integer.
 	 */
@@ -52,6 +61,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with a false type for a version.
+	 *
+	 * @covers Whip_VersionRequirement::validateParameters()
 	 *
 	 * @expectedException Whip_InvalidType
 	 * @expectedExceptionMessage Version should be of type string. Found integer.
@@ -63,6 +74,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with a an empty operator.
 	 *
+	 * @covers Whip_VersionRequirement::validateParameters()
+	 *
 	 * @expectedException Whip_EmptyProperty
 	 * @expectedExceptionMessage Operator cannot be empty.
 	 */
@@ -72,6 +85,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with a false type for an operator.
+	 *
+	 * @covers Whip_VersionRequirement::validateParameters()
 	 *
 	 * @expectedException Whip_InvalidType
 	 * @expectedExceptionMessage Operator should be of type string. Found integer.
@@ -83,6 +98,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with an invalid operator.
 	 *
+	 * @covers Whip_VersionRequirement::validateParameters()
+	 *
 	 * @expectedException Whip_InvalidOperatorType
 	 * @expectedExceptionMessage Invalid operator of -> used. Please use one of the following operators: =, ==, ===, <, >, <=, >=
 	 */
@@ -92,6 +109,10 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Creates a new Whip_VersionRequirement and tests if this is correctly created with its given arguments.
+	 *
+	 * @covers Whip_VersionRequirement::component()
+	 * @covers Whip_VersionRequirement::version()
+	 * @covers Whip_VersionRequirement::operator()
 	 */
 	public function testGettingComponentProperties() {
 		$requirement = new Whip_VersionRequirement( 'php', '5.6' );
@@ -104,9 +125,13 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests whether fromCompareString() correctly returns the expected variables from a passed string.
 	 *
-	 * @param string $expectation      The expected output string.
-	 * @param string $component        The component for this version requirement.
-	 * @param string $compareString    The comparison string for this version requirement.
+	 * @param string $expectation   The expected output string.
+	 * @param string $component     The component for this version requirement.
+	 * @param string $compareString The comparison string for this version requirement.
+	 *
+	 * @covers Whip_VersionRequirement::component()
+	 * @covers Whip_VersionRequirement::version()
+	 * @covers Whip_VersionRequirement::operator()
 	 *
 	 * @throws Whip_InvalidVersionComparisonString When the $compareString parameter is invalid.
 	 *
@@ -138,6 +163,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests whether fromCompareString() correctly throws an exception when provided with an invalid comparison string.
+	 *
+	 * @covers Whip_VersionRequirement::fromCompareString()
 	 *
 	 * @expectedException Whip_InvalidVersionComparisonString
 	 * @expectedExceptionMessage Invalid version comparison string. Example of a valid version comparison string: >=5.3. Passed version comparison string: > 2.3

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -10,6 +10,9 @@
  */
 class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 
+	/**
+	 * Creates a new Whip_VersionRequirement with component php and version 5.2 and tests if this is correctly created.
+	 */
 	public function testNameAndVersionAreNotEmpty() {
 		$requirement = new Whip_VersionRequirement( 'php', '5.2' );
 
@@ -18,6 +21,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with an empty component.
+	 *
 	 * @expectedException Whip_EmptyProperty
 	 * @expectedExceptionMessage Component cannot be empty.
 	 */
@@ -26,6 +31,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with an empty version.
+	 *
 	 * @expectedException Whip_EmptyProperty
 	 * @expectedExceptionMessage Version cannot be empty.
 	 */
@@ -34,6 +41,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with a false type for a component.
+	 *
 	 * @expectedException Whip_InvalidType
 	 * @expectedExceptionMessage Component should be of type string. Found integer.
 	 */
@@ -42,6 +51,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with a false type for a version.
+	 *
 	 * @expectedException Whip_InvalidType
 	 * @expectedExceptionMessage Version should be of type string. Found integer.
 	 */
@@ -50,6 +61,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with a an empty operator.
+	 *
 	 * @expectedException Whip_EmptyProperty
 	 * @expectedExceptionMessage Operator cannot be empty.
 	 */
@@ -58,6 +71,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with a false type for an operator.
+	 *
 	 * @expectedException Whip_InvalidType
 	 * @expectedExceptionMessage Operator should be of type string. Found integer.
 	 */
@@ -66,6 +81,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement is created with an invalid operator.
+	 *
 	 * @expectedException Whip_InvalidOperatorType
 	 * @expectedExceptionMessage Invalid operator of -> used. Please use one of the following operators: =, ==, ===, <, >, <=, >=
 	 */
@@ -73,6 +90,9 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 		new Whip_VersionRequirement( 'php', '5.2', '->' );
 	}
 
+	/**
+	 * Creates a new Whip_VersionRequirement and tests if this is correctly created with its given arguments.
+	 */
 	public function testGettingComponentProperties() {
 		$requirement = new Whip_VersionRequirement( 'php', '5.6' );
 
@@ -82,6 +102,14 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests whether fromCompareString() correctly returns the expected variables from a passed string.
+	 *
+	 * @param string $expectation      The expected output string.
+	 * @param string $component        The component for this version requirement.
+	 * @param string $compareString    The comparison string for this version requirement.
+	 *
+	 * @throws Whip_InvalidVersionComparisonString When the $compareString parameter is invalid.
+	 *
 	 * @dataProvider dataFromCompareString
 	 */
 	public function testFromCompareString( $expectation, $component, $compareString ) {
@@ -92,6 +120,9 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( $expectation[2], $requirement->operator() );
 	}
 
+	/**
+	 * Provides data to test fromCompareString with.
+	 */
 	public function dataFromCompareString() {
 		return array(
 			array( array( 'php', '5.5', '>' ), 'php', '>5.5' ),
@@ -106,6 +137,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests whether fromCompareString() correctly throws an exception when provided with an invalid comparison string.
+	 *
 	 * @expectedException Whip_InvalidVersionComparisonString
 	 * @expectedExceptionMessage Invalid version comparison string. Example of a valid version comparison string: >=5.3. Passed version comparison string: > 2.3
 	 */

--- a/tests/doubles/WPCoreFunctionsMock.php
+++ b/tests/doubles/WPCoreFunctionsMock.php
@@ -14,7 +14,7 @@ if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
  *
  * @param string $message The message to return.
  *
- * @return string
+ * @return string The message that is returned.
  */
 function __( $message ) {
 	return $message;
@@ -25,7 +25,7 @@ function __( $message ) {
  *
  * @param string $url The url to return.
  *
- * @return string
+ * @return string The url that is returned.
  */
 function esc_url( $url ) {
 	return $url;

--- a/tests/doubles/WPCoreFunctionsMock.php
+++ b/tests/doubles/WPCoreFunctionsMock.php
@@ -9,10 +9,24 @@ if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
 	define( 'WEEK_IN_SECONDS', ( 60 * 60 * 24 * 7 ) );
 }
 
+/**
+ * Returns the message.
+ *
+ * @param string $message The message to return.
+ *
+ * @return string
+ */
 function __( $message ) {
 	return $message;
 }
 
+/**
+ * Returns the url.
+ *
+ * @param string $url The url to return.
+ *
+ * @return string
+ */
 function esc_url( $url ) {
 	return $url;
 }

--- a/tests/doubles/Whip_DismissStorageMock.php
+++ b/tests/doubles/Whip_DismissStorageMock.php
@@ -11,7 +11,7 @@
 class Whip_DismissStorageMock implements Whip_DismissStorage {
 
 	/**
-	 * Creates $dismissed and sets it to 0.
+	 * Holds the dismissed state.
 	 *
 	 * @var int
 	 */

--- a/tests/doubles/Whip_DismissStorageMock.php
+++ b/tests/doubles/Whip_DismissStorageMock.php
@@ -11,6 +11,8 @@
 class Whip_DismissStorageMock implements Whip_DismissStorage {
 
 	/**
+	 * Creates $dismissed and sets it to 0.
+	 *
 	 * @var int
 	 */
 	protected $dismissed = 0;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Added documentation (mostly descriptions) to the unit tests. 
* Removed the exceptions for the lack of documentation for these files from the `.phpcs.xml.dist` file.

## Test instructions
This PR can be tested by following these steps:
* As the changes are just comments in the unit tests nothing should be changed. 
* All unit tests should still pass. 

Fixes #66 
