### PR TITLE
Build/Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
     - $HOME/.cache/composer/files
 
 php:
+- 7.2
 - 7.1
 - 7.0
 - 5.6
@@ -20,7 +21,7 @@ php:
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
+    - php: 7.3
       env: PHPCS=1
     - php: 5.2
       dist: precise


### PR DESCRIPTION
Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev and builds haven't been tested against PHP 7.3 for months now.

As of this week, Travis has (finally) made a PHP 7.3 alias available now RC3 is out, so I've ~~updated the highest PHP version to test against to~~  _added a build to test against_ PHP 7.3 so there won't be any unwelcome surprises when PHP 7.3 comes out.