### PR TITLE
Composer: require YoastCS 1.1.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="Yoast WHIP">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	name="Yoast WHIP"
+	xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
 	<description>Yoast WHIP rules for PHP_CodeSniffer</description>
 
 	<!--

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "^3.6.12 | ^4.5 | ^5.7",
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^1.0.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+        "yoast/yoastcs": "^1.1.0"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
* Includes adding the PHPCS XSD to the custom ruleset which should now be valid as the minimum PHPCS requirement has gone up to PHPCS 3.3.2.
* Includes removing the DealerDirect Composer PHPCS plugin which now comes automatically with YoastCS.

No code CS changes needed.