### PR TITLE
Composer: require YoastCS ^1.2.2

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -101,7 +101,7 @@
 		<type>warning</type>
 	</rule>
 
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound">
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound">
 		<!-- These hook setups should be reviewed.
 			 Ticket: https://github.com/Yoast/whip/issues/67 -->
 		<exclude-pattern>/src/Whip_Host\.php$</exclude-pattern>

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "^3.6.12 | ^4.5 | ^5.7",
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^1.1.0"
+        "yoast/yoastcs": "^1.2.2"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
Updates the CS requirements to YoastCS 1.2.2.

Includes minor ruleset update for changed sniff error code in WPCS 2.0.0.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/1.2.0
* https://github.com/Yoast/yoastcs/releases/tag/1.2.1
* https://github.com/Yoast/yoastcs/releases/tag/1.2.2
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/2.0.0-RC1
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/2.0.0