### PR TITLE
PHPCS ruleset: update the prefixes array

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -80,6 +80,7 @@
 			<!-- Provide the prefixes to look for. -->
 			<property name="prefixes" type="array">
 				<element value="whip"/>
+				<element value="Yoast\WHIP"/>
 			</property>
 		</properties>
 


### PR DESCRIPTION
... to cover both the prefix for global structures as well as for namespaced structures based on the agreed prefixes per September 2018.