### PR TITLE
Composer: sync with other config files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "yoast/whip",
     "description": "A WordPress package to nudge users to upgrade their software versions (starting with PHP)",
     "type": "library",
+    "homepage": "https://github.com/Yoast/whip",
     "license": "GPL-3.0-or-later",
     "authors": [
         {
@@ -9,6 +10,10 @@
             "email": "support@yoast.com"
         }
     ],
+    "support"    : {
+        "issues": "https://github.com/Yoast/whip/issues",
+        "source": "https://github.com/Yoast/whip"
+    },
     "autoload": {
         "files": [
             "src/facades/wordpress.php"
@@ -18,6 +23,7 @@
         ]
     },
     "require": {
+        "php": ">=5.2",
         "xrstf/composer-php52": "^1.0"
     },
     "require-dev": {
@@ -25,6 +31,8 @@
         "roave/security-advisories": "dev-master",
         "yoast/yoastcs": "^1.1.0"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
         "post-install-cmd": [
             "xrstf\\Composer52\\Generator::onPostInstallCmd"
@@ -35,8 +43,18 @@
         "post-autoload-dump": [
             "xrstf\\Composer52\\Generator::onPostInstallCmd"
         ],
+        "config-yoastcs" : [
+            "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
+        ],
+        "check-cs": [
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+        ],
+        "fix-cs": [
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+        ],
         "test": [
-            "vendor/bin/phpunit"
+            "@php ./vendor/phpunit/phpunit/phpunit"
         ]
     }
 }


### PR DESCRIPTION
I've done a compare between the `composer.json` config files in (nearly) all plugin repos.

This commit adds some additional properties to the config file to improve consistency with the other repos and predictability for devs.

* Adds an explicit minimum PHP version.
* Adds `config-yoastcs`, `check-cs` and `fix-cs` scripts for use by devs.
    Note: the `config-yoastcs` script is not _needed_ as the DealerDirect plugin sorts this out automatically, however for consistency of the scripts between repos, this has been added anyway.
* Makes the existing `test` script respect the PHP version Composer is run on.
     See Yoast/yoastcs#114 for a more detailed explanation.
* Add a few miscellaneous other properties.