### PR TITLE
Travis: test builds against PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ php:
 - 5.6
 - 5.5
 - 5.4
-- nightly
+- "7.4snapshot"
 
 matrix:
   fast_finish: true
@@ -30,7 +30,7 @@ matrix:
 
   allow_failures:
     # Allow failures for unstable builds.
-    - php: nightly
+    - php: "7.4snapshot"
 
 before_install:
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'


### PR DESCRIPTION
Nightly has become PHP 8.0 since PHP 7.4 has been branched, so to continue to also test against PHP 7.4, it needs to be added separately.

Refs:
* https://twitter.com/nikita_ppv/status/1089839541828112384
* https://twitter.com/nikita_ppv/status/1094897743594770433