### PR TITLE
Test documentation: align the contents of tags

### DIFF
--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -13,7 +13,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests the creation of a Whip_Configuration with invalid input.
 	 *
-	 * @expectedException Whip_InvalidType
+	 * @expectedException        Whip_InvalidType
 	 * @expectedExceptionMessage Configuration should be of type array. Found string.
 	 */
 	public function testItThrowsAnErrorIfAFaultyConfigurationIsPassed() {

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -24,7 +24,7 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if an Exception is correctly thrown when an empty string is passed as argument.
 	 *
-	 * @expectedException Whip_EmptyProperty
+	 * @expectedException        Whip_EmptyProperty
 	 * @expectedExceptionMessage Message body cannot be empty.
 	 *
 	 * @covers Whip_BasicMessage::validateParameters()
@@ -36,7 +36,7 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if an Exception is correctly thrown when an invalid type is passed as argument.
 	 *
-	 * @expectedException Whip_InvalidType
+	 * @expectedException        Whip_InvalidType
 	 * @expectedExceptionMessage Message body should be of type string. Found integer.
 	 *
 	 * @covers Whip_BasicMessage::validateParameters()

--- a/tests/RequirementsCheckerTest.php
+++ b/tests/RequirementsCheckerTest.php
@@ -36,7 +36,7 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if Whip_RequirementsChecker throws an error when passed an invalid requirement.
 	 *
-	 * @covers Whip_RequirementsChecker::addRequirement()
+	 * @covers   Whip_RequirementsChecker::addRequirement()
 	 * @requires PHP 7
 	 */
 	public function testItThrowsAnTypeErrorWhenInvalidRequirementIsPassed() {

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -28,7 +28,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters()
 	 *
-	 * @expectedException Whip_EmptyProperty
+	 * @expectedException        Whip_EmptyProperty
 	 * @expectedExceptionMessage Component cannot be empty.
 	 */
 	public function testComponentCannotBeEmpty() {
@@ -40,7 +40,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters()
 	 *
-	 * @expectedException Whip_EmptyProperty
+	 * @expectedException        Whip_EmptyProperty
 	 * @expectedExceptionMessage Version cannot be empty.
 	 */
 	public function testVersionCannotBeEmpty() {
@@ -52,7 +52,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters()
 	 *
-	 * @expectedException Whip_InvalidType
+	 * @expectedException        Whip_InvalidType
 	 * @expectedExceptionMessage Component should be of type string. Found integer.
 	 */
 	public function testComponentMustBeString() {
@@ -64,7 +64,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters()
 	 *
-	 * @expectedException Whip_InvalidType
+	 * @expectedException        Whip_InvalidType
 	 * @expectedExceptionMessage Version should be of type string. Found integer.
 	 */
 	public function testVersionMustBeString() {
@@ -76,7 +76,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters()
 	 *
-	 * @expectedException Whip_EmptyProperty
+	 * @expectedException        Whip_EmptyProperty
 	 * @expectedExceptionMessage Operator cannot be empty.
 	 */
 	public function testOperatorCannotBeEmpty() {
@@ -88,7 +88,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters()
 	 *
-	 * @expectedException Whip_InvalidType
+	 * @expectedException        Whip_InvalidType
 	 * @expectedExceptionMessage Operator should be of type string. Found integer.
 	 */
 	public function testOperatorMustBeString() {
@@ -100,7 +100,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters()
 	 *
-	 * @expectedException Whip_InvalidOperatorType
+	 * @expectedException        Whip_InvalidOperatorType
 	 * @expectedExceptionMessage Invalid operator of -> used. Please use one of the following operators: =, ==, ===, <, >, <=, >=
 	 */
 	public function testOperatorMustBeValid() {
@@ -166,7 +166,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @covers Whip_VersionRequirement::fromCompareString()
 	 *
-	 * @expectedException Whip_InvalidVersionComparisonString
+	 * @expectedException        Whip_InvalidVersionComparisonString
 	 * @expectedExceptionMessage Invalid version comparison string. Example of a valid version comparison string: >=5.3. Passed version comparison string: > 2.3
 	 */
 	public function testFromCompareStringException() {


### PR DESCRIPTION
The comment text for grouped tags should start one space after the longest tag name.