### PR TITLE
Tests: improve test skipping

### DIFF
--- a/tests/RequirementsCheckerTest.php
+++ b/tests/RequirementsCheckerTest.php
@@ -40,8 +40,8 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	 * @requires PHP 7
 	 */
 	public function testItThrowsAnTypeErrorWhenInvalidRequirementIsPassed() {
-		if ( version_compare( phpversion(), 7.0, '<' ) ) {
-			$this->markTestSkipped( 'Skipped due to incompatible PHP version.' );
+		if ( version_compare( phpversion(), '7.0', '<' ) ) {
+			$this->markTestSkipped( 'Skipped due to incompatible PHP version: this test only runs on PHP 7+.' );
 		}
 
 		$exceptionCaught = false;
@@ -63,8 +63,8 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	 * @covers Whip_RequirementsChecker::addRequirement()
 	 */
 	public function testItThrowsAnTypeErrorWhenInvalidRequirementIsPassedInPHP5() {
-		if ( version_compare( phpversion(), 7.0, '>=' ) ) {
-			$this->markTestSkipped();
+		if ( version_compare( phpversion(), '7.0', '>=' ) ) {
+			$this->markTestSkipped( 'Skipped due to incompatible PHP version: this test only runs on PHP 5.x.' );
 		}
 
 		$exceptionCaught = false;


### PR DESCRIPTION
* The `version_compare()` function expects string input, so the floats passed as the second parameter should be strings.
    Ref: https://www.php.net/manual/en/function.version-compare.php
* Made sure skipped tests will always have an explanation on why the test is skipped.
    Ref: https://phpunit.de/manual/6.5/en/incomplete-and-skipped-tests.html#incomplete-and-skipped-tests.skipping-tests