### PR TITLE
QA: use the most specific PHPUnit assertion possible

### DIFF
--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -36,7 +36,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 			->method( 'component' )
 			->will( $this->returnValue( 'mysql' ) );
 
-		$this->assertEquals( -1, $configuration->configuredVersion( $requirement ) );
+		$this->assertSame( -1, $configuration->configuredVersion( $requirement ) );
 	}
 
 	/**
@@ -55,7 +55,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 			->method( 'component' )
 			->will( $this->returnValue( 'php' ) );
 
-		$this->assertEquals( '5.6', $configuration->configuredVersion( $requirement ) );
+		$this->assertSame( '5.6', $configuration->configuredVersion( $requirement ) );
 	}
 
 	/**

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -31,11 +31,11 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 		$storage     = new Whip_DismissStorageMock();
 		$dismisser   = new Whip_MessageDismisser( $currentTime, ( WEEK_IN_SECONDS * 4 ), $storage );
 
-		$this->assertEquals( 0, $storage->get() );
+		$this->assertSame( 0, $storage->get() );
 
 		$dismisser->dismiss();
 
-		$this->assertEquals( $currentTime, $storage->get() );
+		$this->assertSame( $currentTime, $storage->get() );
 	}
 
 	/**
@@ -55,7 +55,7 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 		$storage->set( $savedTime );
 		$dismisser = new Whip_MessageDismisser( $currentTime, ( WEEK_IN_SECONDS * 4 ), $storage );
 
-		$this->assertEquals( $expected, $dismisser->isDismissed() );
+		$this->assertSame( $expected, $dismisser->isDismissed() );
 	}
 
 	/**

--- a/tests/RequirementsCheckerTest.php
+++ b/tests/RequirementsCheckerTest.php
@@ -30,7 +30,7 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 		$checker->addRequirement( new Whip_VersionRequirement( 'php', '5.2' ) );
 
 		$this->assertTrue( $checker->hasRequirements() );
-		$this->assertEquals( 1, $checker->totalRequirements() );
+		$this->assertSame( 1, $checker->totalRequirements() );
 	}
 
 	/**
@@ -93,11 +93,11 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 		$checker->addRequirement( new Whip_VersionRequirement( 'mysql', '5.6' ) );
 
 		$this->assertTrue( $checker->hasRequirements() );
-		$this->assertEquals( 2, $checker->totalRequirements() );
+		$this->assertSame( 2, $checker->totalRequirements() );
 
 		$checker->addRequirement( new Whip_VersionRequirement( 'php', '6' ) );
 
-		$this->assertEquals( 2, $checker->totalRequirements() );
+		$this->assertSame( 2, $checker->totalRequirements() );
 	}
 
 	/**

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -117,9 +117,9 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	public function testGettingComponentProperties() {
 		$requirement = new Whip_VersionRequirement( 'php', '5.6' );
 
-		$this->assertEquals( 'php', $requirement->component() );
-		$this->assertEquals( '5.6', $requirement->version() );
-		$this->assertEquals( '=', $requirement->operator() );
+		$this->assertSame( 'php', $requirement->component() );
+		$this->assertSame( '5.6', $requirement->version() );
+		$this->assertSame( '=', $requirement->operator() );
 	}
 
 	/**
@@ -140,9 +140,9 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	public function testFromCompareString( $expectation, $component, $compareString ) {
 		$requirement = Whip_VersionRequirement::fromCompareString( $component, $compareString );
 
-		$this->assertEquals( $expectation[0], $requirement->component() );
-		$this->assertEquals( $expectation[1], $requirement->version() );
-		$this->assertEquals( $expectation[2], $requirement->operator() );
+		$this->assertSame( $expectation[0], $requirement->component() );
+		$this->assertSame( $expectation[1], $requirement->version() );
+		$this->assertSame( $expectation[2], $requirement->operator() );
 	}
 
 	/**


### PR DESCRIPTION
This is a long established best practice.

PHPUnit contains a variety of assertions and the ones available has been extended  hugely over the years.
To have the most reliable tests, the most specific assertion should be used.

This implements this for WHIP, while keeping in mind that at this time, PHPUnit 3.x should still be supported.

Refs:
* https://phpunit.de/manual/3.6/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.assertions
* https://phpunit.readthedocs.io/en/7.5/assertions.html#

Most notably, this changes calls to `assertEquals()` to `assertSame()`, where `assertEquals()` does a loose type comparison and `assertSame()` does a strict type comparison.

Refs:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame