### PR TITLE
QA: PHPUnit cross-version compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "xrstf/composer-php52": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^3.6.12 | ^4.5 | ^5.7",
+        "phpunit/phpunit": "^3.6.12 || ^4.5 || ^5.7 || ^6.0 || ^7.0",
         "roave/security-advisories": "dev-master",
         "yoast/yoastcs": "^1.2.2"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,19 @@
-<phpunit bootstrap="tests/bootstrap.php">
-    <testsuites>
-        <testsuite>
-            <directory suffix="Test.php">./tests/</directory>
-        </testsuite>
-    </testsuites>
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.5/phpunit.xsd"
+		backupGlobals="true"
+		bootstrap="tests/bootstrap.php"
+	>
+	<testsuites>
+		<testsuite name="whip">
+			<directory suffix="Test.php">./tests/</directory>
+		</testsuite>
+	</testsuites>
 
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-        </whitelist>
-    </filter>
+	<filter>
+		<whitelist>
+			<directory>./src</directory>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,22 @@
  * @package Yoast\WHIP
  */
 
+/*
+ * PHPUnit cross version compatibility.
+ *
+ * The classes in PHPUnit have been renamed to namespaced classes.
+ * The namespaced alias for the TestCase class is available as of PHPUnit 5.4 and as of
+ * PHPUnit 6.0, the non-namespaced versions are no longer available.
+ * As PHPUnit 6.0 requires PHP 7 anyway, the PHP 5.3 function class_alias() will be available,
+ * so we can use it to alias the class back to the old class name.
+ */
+if ( class_exists( 'PHPUnit\Framework\TestCase' ) === true
+	&& class_exists( 'PHPUnit_Framework_TestCase' ) === false
+) {
+	// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.class_aliasFound
+	class_alias( 'PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase' );
+}
+
 if ( file_exists( dirname( __FILE__ ) . '/../vendor/autoload_52.php' ) ) {
 	require_once dirname( __FILE__ ) . '/../vendor/autoload_52.php';
 }


### PR DESCRIPTION
## Make the unit tests PHPUnit cross-version compatible

To test the code in this repository on all supported stable PHP versions, PHPUnit 3.x up to 7.x should be supported.

PHP 5.2 needs PHPUnit 3.x
PHPUnit 4.x will run on PHP 5.3. - 5.6.
PHPUnit 5.x will run on PHP 5.6 - 7.1.
PHPUnit 6.x will run on PHP 7.0 - 7.2.
PHPUnit 7.x will run on PHP 7.1 - 7.3.

For now, PHPUnit 7.x will also work fine for PHP 7.4 (unstable), so supporting PHPUnit 8.x is not yet necessary.
Ref: https://phpunit.de/supported-versions.html

As WHIP is about motivating people to upgrade to higher PHP versions, dropping support for PHP 5.2/PHPUnit 3.x is not (yet) a good idea.

With that in mind, the simplest change has been made to allow the unit tests to be cross-version compatible.

## CI/QA: make the phpunit.xml.dist file cross-version compatible

The specs for the `phpunit.xml.dist` file have changed numerous times over the years with new options being added and outdated options being removed.
These specs are contained in a schema XSD file for each minor PHPUnit version.

This commit:
* Adds a proper XML file header;
* Annotates that an XSD schema is available and used;
* Adds the `backupGlobals` directive.
    The default value for the top-level `backupGlobals` directive has [changed in PHPunit 6 from `true` to `false`](https://phpunit.de/announcements/phpunit-6.html). To maintain the same behaviour cross-version, this directive is now explicitly set in the config file.
* Adds a `name` to the testsuite.
    As of PHPUnit 7, each testsuite is required to have a `name` attribute. Prior to that version, the `name` attribute was already allowed, so adding the attribute improves cross-version compatibility of the config file.
* Fixes the indentation to tabs.

What I have not changed:
* The `testsuite` node was not allowed according to the XSD until PHPUnit 4.4, however as the config with the `testsuite` works just fine in PHPUnit 3.x and 4.x, this is not an issue.