### PR TITLE
Test bootstrap: show friendly error message on failure

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,3 +8,7 @@
 if ( file_exists( dirname( __FILE__ ) . '/../vendor/autoload_52.php' ) ) {
 	require_once dirname( __FILE__ ) . '/../vendor/autoload_52.php';
 }
+else {
+	echo 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.' . PHP_EOL;
+	exit( 1 );
+}


### PR DESCRIPTION
Show an instructive error message when the Composer autoload file can not be found.

Without this change a fatal PHP error would be shown which isn't very helpful to people new to the repo.