### PR TITLE
Tests: add missing @covers tag

### DIFF
--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -15,6 +15,8 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @expectedException        Whip_InvalidType
 	 * @expectedExceptionMessage Configuration should be of type array. Found string.
+	 *
+	 * @covers Whip_Configuration::__construct
 	 */
 	public function testItThrowsAnErrorIfAFaultyConfigurationIsPassed() {
 		$configuration = new Whip_Configuration( 'Invalid configuration' );


### PR DESCRIPTION
Each test should have a `@covers` tag in the function docblock to document what is being tested and to make sure that no accidental code coverage will be recorded.

For more information, see: https://github.com/Yoast/yoastcs/issues/123