### PR TITLE
 Test documentation: fix @covers tags

### DIFF
--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -23,7 +23,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if Whip_Configuration correctly returns -1 when passed an unknown requirement.
 	 *
-	 * @covers Whip_Configuration::configuredVersion()
+	 * @covers Whip_Configuration::configuredVersion
 	 */
 	public function testItReturnsANegativeNumberIfRequirementCannotBeFound() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );
@@ -42,7 +42,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if Whip_Configuration correctly returns the version number when passed a valid requirement.
 	 *
-	 * @covers Whip_Configuration::configuredVersion()
+	 * @covers Whip_Configuration::configuredVersion
 	 */
 	public function testItReturnsAnEntryIfRequirementIsFound() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );
@@ -61,7 +61,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if hasRequirementConfigures correctly returns true/false when called with valid/invalid values.
 	 *
-	 * @covers Whip_Configuration::hasRequirementConfigured()
+	 * @covers Whip_Configuration::hasRequirementConfigured
 	 */
 	public function testIfRequirementIsConfigured() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -23,8 +23,8 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if Whip_MessageDismisser correctly updates Whip_DismissStorage.
 	 *
-	 * @covers Whip_MessageDismisser::__construct()
-	 * @covers Whip_MessageDismisser::dismiss()
+	 * @covers Whip_MessageDismisser::__construct
+	 * @covers Whip_MessageDismisser::dismiss
 	 */
 	public function testDismiss() {
 		$currentTime = time();
@@ -47,8 +47,8 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 	 * @param int  $currentTime The current time.
 	 * @param bool $expected    The expected value.
 	 *
-	 * @covers Whip_MessageDismisser::__construct()
-	 * @covers Whip_MessageDismisser::isDismissed()
+	 * @covers Whip_MessageDismisser::__construct
+	 * @covers Whip_MessageDismisser::isDismissed
 	 */
 	public function testIsDismissibleWithVersions( $savedTime, $currentTime, $expected ) {
 		$storage = new Whip_DismissStorageMock();

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -13,7 +13,7 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if Whip_BasicMessage correctly handles a string for its body argument.
 	 *
-	 * @covers Whip_BasicMessage::body()
+	 * @covers Whip_BasicMessage::body
 	 */
 	public function testMessageHasBody() {
 		$message = new Whip_BasicMessage( 'This is a message' );
@@ -27,7 +27,7 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 	 * @expectedException        Whip_EmptyProperty
 	 * @expectedExceptionMessage Message body cannot be empty.
 	 *
-	 * @covers Whip_BasicMessage::validateParameters()
+	 * @covers Whip_BasicMessage::validateParameters
 	 */
 	public function testMessageCannotBeEmpty() {
 		new Whip_BasicMessage( '' );
@@ -39,7 +39,7 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 	 * @expectedException        Whip_InvalidType
 	 * @expectedExceptionMessage Message body should be of type string. Found integer.
 	 *
-	 * @covers Whip_BasicMessage::validateParameters()
+	 * @covers Whip_BasicMessage::validateParameters
 	 */
 	public function testMessageMustBeString() {
 		new Whip_BasicMessage( 123 );

--- a/tests/MessagesManagerTest.php
+++ b/tests/MessagesManagerTest.php
@@ -14,7 +14,7 @@ class MessagesManagerTest extends PHPUnit_Framework_TestCase {
 	 * Creates a MessagesManager, calls hasMessages and tests if it returns false
 	 * without a message, true when given a message.
 	 *
-	 * @covers Whip_MessagesManager::hasMessages()
+	 * @covers Whip_MessagesManager::hasMessages
 	 */
 	public function testHasMessages() {
 		$manager = new Whip_MessagesManager();

--- a/tests/RequirementsCheckerTest.php
+++ b/tests/RequirementsCheckerTest.php
@@ -22,8 +22,8 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if Whip_RequirementsChecker is successfully created when given valid arguments.
 	 *
-	 * @covers Whip_RequirementsChecker::addRequirement()
-	 * @covers Whip_RequirementsChecker::totalRequirements()
+	 * @covers Whip_RequirementsChecker::addRequirement
+	 * @covers Whip_RequirementsChecker::totalRequirements
 	 */
 	public function testItReceivesAUsableRequirementObject() {
 		$checker = new Whip_RequirementsChecker();
@@ -36,7 +36,7 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if Whip_RequirementsChecker throws an error when passed an invalid requirement.
 	 *
-	 * @covers   Whip_RequirementsChecker::addRequirement()
+	 * @covers   Whip_RequirementsChecker::addRequirement
 	 * @requires PHP 7
 	 */
 	public function testItThrowsAnTypeErrorWhenInvalidRequirementIsPassed() {
@@ -60,7 +60,7 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if Whip_RequirementsChecker throws an error when passed an invalid requirement.
 	 *
-	 * @covers Whip_RequirementsChecker::addRequirement()
+	 * @covers Whip_RequirementsChecker::addRequirement
 	 */
 	public function testItThrowsAnTypeErrorWhenInvalidRequirementIsPassedInPHP5() {
 		if ( version_compare( phpversion(), '7.0', '>=' ) ) {
@@ -83,8 +83,8 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if Whip_RequirementsChecker only saves unique components.
 	 *
-	 * @covers Whip_RequirementsChecker::addRequirement()
-	 * @covers Whip_RequirementsChecker::totalRequirements()
+	 * @covers Whip_RequirementsChecker::addRequirement
+	 * @covers Whip_RequirementsChecker::totalRequirements
 	 */
 	public function testItOnlyContainsUniqueComponents() {
 		$checker = new Whip_RequirementsChecker();
@@ -104,8 +104,8 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	 * Tests if Whip_RequirementsChecker::requirementExistsForComponent correctly
 	 * returns true for existing components.
 	 *
-	 * @covers Whip_RequirementsChecker::addRequirement()
-	 * @covers Whip_RequirementsChecker::requirementExistsForComponent()
+	 * @covers Whip_RequirementsChecker::addRequirement
+	 * @covers Whip_RequirementsChecker::requirementExistsForComponent
 	 */
 	public function testIfRequirementExists() {
 		$checker = new Whip_RequirementsChecker();
@@ -122,10 +122,10 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * Verifies that a php upgrade message is created and successfully transferred to a variable.
 	 *
-	 * @covers Whip_RequirementsChecker::addRequirement()
-	 * @covers Whip_RequirementsChecker::check()
-	 * @covers Whip_RequirementsChecker::hasMessages()
-	 * @covers Whip_RequirementsChecker::getMostRecentMessage()
+	 * @covers Whip_RequirementsChecker::addRequirement
+	 * @covers Whip_RequirementsChecker::check
+	 * @covers Whip_RequirementsChecker::hasMessages
+	 * @covers Whip_RequirementsChecker::getMostRecentMessage
 	 */
 	public function testCheckIfPHPRequirementIsNotFulfilled() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => 4 ) );
@@ -147,9 +147,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if there no message when the requirement is fulfilled.
 	 *
-	 * @covers Whip_RequirementsChecker::addRequirement()
-	 * @covers Whip_RequirementsChecker::check()
-	 * @covers Whip_RequirementsChecker::getMostRecentMessage()
+	 * @covers Whip_RequirementsChecker::addRequirement
+	 * @covers Whip_RequirementsChecker::check
+	 * @covers Whip_RequirementsChecker::getMostRecentMessage
 	 */
 	public function testCheckIfRequirementIsFulfilled() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => phpversion() ) );
@@ -165,10 +165,10 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * Verifies that an invalid version message is created and successfully transferred to a variable.
 	 *
-	 * @covers Whip_RequirementsChecker::addRequirement()
-	 * @covers Whip_RequirementsChecker::check()
-	 * @covers Whip_RequirementsChecker::getMostRecentMessage()
-	 * @covers Whip_RequirementsChecker::hasMessages()
+	 * @covers Whip_RequirementsChecker::addRequirement
+	 * @covers Whip_RequirementsChecker::check
+	 * @covers Whip_RequirementsChecker::getMostRecentMessage
+	 * @covers Whip_RequirementsChecker::hasMessages
 	 */
 	public function testCheckIfRequirementIsNotFulfilled() {
 		$checker = new Whip_RequirementsChecker( array( 'mysql' => 4 ) );
@@ -190,9 +190,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if a specific comparison with a non-default operator is correctly handled.
 	 *
-	 * @covers Whip_RequirementsChecker::addRequirement()
-	 * @covers Whip_RequirementsChecker::check()
-	 * @covers Whip_RequirementsChecker::hasMessages()
+	 * @covers Whip_RequirementsChecker::addRequirement
+	 * @covers Whip_RequirementsChecker::check
+	 * @covers Whip_RequirementsChecker::hasMessages
 	 */
 	public function testCheckIfRequirementIsFulfilledWithSpecificComparison() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => 4 ) );
@@ -206,9 +206,9 @@ class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests if a specific comparison with a non-default operator is correctly handled.
 	 *
-	 * @covers Whip_RequirementsChecker::addRequirement()
-	 * @covers Whip_RequirementsChecker::check()
-	 * @covers Whip_RequirementsChecker::hasMessages()
+	 * @covers Whip_RequirementsChecker::addRequirement
+	 * @covers Whip_RequirementsChecker::check
+	 * @covers Whip_RequirementsChecker::hasMessages
 	 */
 	public function testCheckIfRequirementIsNotFulfilledWithSpecificComparison() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => 4 ) );

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -14,8 +14,8 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 * Creates a new Whip_VersionRequirement with component php and version 5.2 and
 	 * tests if this is correctly created.
 	 *
-	 * @covers Whip_VersionRequirement::component()
-	 * @covers Whip_VersionRequirement::version()
+	 * @covers Whip_VersionRequirement::component
+	 * @covers Whip_VersionRequirement::version
 	 */
 	public function testNameAndVersionAreNotEmpty() {
 		$requirement = new Whip_VersionRequirement( 'php', '5.2' );
@@ -28,7 +28,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement
 	 * is created with an empty component.
 	 *
-	 * @covers Whip_VersionRequirement::validateParameters()
+	 * @covers Whip_VersionRequirement::validateParameters
 	 *
 	 * @expectedException        Whip_EmptyProperty
 	 * @expectedExceptionMessage Component cannot be empty.
@@ -41,7 +41,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement
 	 * is created with an empty version.
 	 *
-	 * @covers Whip_VersionRequirement::validateParameters()
+	 * @covers Whip_VersionRequirement::validateParameters
 	 *
 	 * @expectedException        Whip_EmptyProperty
 	 * @expectedExceptionMessage Version cannot be empty.
@@ -54,7 +54,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement
 	 * is created with a false type for a component.
 	 *
-	 * @covers Whip_VersionRequirement::validateParameters()
+	 * @covers Whip_VersionRequirement::validateParameters
 	 *
 	 * @expectedException        Whip_InvalidType
 	 * @expectedExceptionMessage Component should be of type string. Found integer.
@@ -67,7 +67,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement
 	 * is created with a false type for a version.
 	 *
-	 * @covers Whip_VersionRequirement::validateParameters()
+	 * @covers Whip_VersionRequirement::validateParameters
 	 *
 	 * @expectedException        Whip_InvalidType
 	 * @expectedExceptionMessage Version should be of type string. Found integer.
@@ -80,7 +80,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement
 	 * is created with an empty operator.
 	 *
-	 * @covers Whip_VersionRequirement::validateParameters()
+	 * @covers Whip_VersionRequirement::validateParameters
 	 *
 	 * @expectedException        Whip_EmptyProperty
 	 * @expectedExceptionMessage Operator cannot be empty.
@@ -93,7 +93,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement
 	 * is created with a false type for an operator.
 	 *
-	 * @covers Whip_VersionRequirement::validateParameters()
+	 * @covers Whip_VersionRequirement::validateParameters
 	 *
 	 * @expectedException        Whip_InvalidType
 	 * @expectedExceptionMessage Operator should be of type string. Found integer.
@@ -106,7 +106,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 * Tests if an Exception message is correctly thrown when a Whip_VersionRequirement
 	 * is created with an invalid operator.
 	 *
-	 * @covers Whip_VersionRequirement::validateParameters()
+	 * @covers Whip_VersionRequirement::validateParameters
 	 *
 	 * @expectedException        Whip_InvalidOperatorType
 	 * @expectedExceptionMessage Invalid operator of -> used. Please use one of the following operators: =, ==, ===, <, >, <=, >=
@@ -118,9 +118,9 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Creates a new Whip_VersionRequirement and tests if this is correctly created with its given arguments.
 	 *
-	 * @covers Whip_VersionRequirement::component()
-	 * @covers Whip_VersionRequirement::version()
-	 * @covers Whip_VersionRequirement::operator()
+	 * @covers Whip_VersionRequirement::component
+	 * @covers Whip_VersionRequirement::version
+	 * @covers Whip_VersionRequirement::operator
 	 */
 	public function testGettingComponentProperties() {
 		$requirement = new Whip_VersionRequirement( 'php', '5.6' );
@@ -137,9 +137,9 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 * @param string $component     The component for this version requirement.
 	 * @param string $compareString The comparison string for this version requirement.
 	 *
-	 * @covers Whip_VersionRequirement::component()
-	 * @covers Whip_VersionRequirement::version()
-	 * @covers Whip_VersionRequirement::operator()
+	 * @covers Whip_VersionRequirement::component
+	 * @covers Whip_VersionRequirement::version
+	 * @covers Whip_VersionRequirement::operator
 	 *
 	 * @throws Whip_InvalidVersionComparisonString When the $compareString parameter is invalid.
 	 *
@@ -173,7 +173,7 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	 * Tests whether fromCompareString() correctly throws an exception when provided
 	 * with an invalid comparison string.
 	 *
-	 * @covers Whip_VersionRequirement::fromCompareString()
+	 * @covers Whip_VersionRequirement::fromCompareString
 	 *
 	 * @expectedException        Whip_InvalidVersionComparisonString
 	 * @expectedExceptionMessage Invalid version comparison string. Example of a valid version comparison string: >=5.3. Passed version comparison string: > 2.3


### PR DESCRIPTION
`@covers` tags are used to indicate what class/method/function a test covers when calculating code coverage of the tests and should follow the specifications of PHPUnit.

Ref:
* https://phpunit.de/manual/6.5/en/appendixes.annotations.html#appendixes.annotations.covers
* https://github.com/Yoast/yoastcs/issues/123