### PR TITLE
PHP 7.4 compatibility fix / implode argument order

### DIFF
--- a/src/messages/Whip_HostMessage.php
+++ b/src/messages/Whip_HostMessage.php
@@ -46,7 +46,7 @@ class Whip_HostMessage implements Whip_Message {
 		$message[] = Whip_MessageFormatter::strong( $this->title() ) . '<br />';
 		$message[] = Whip_MessageFormatter::paragraph( Whip_Host::message( $this->messageKey ) );
 
-		return implode( $message, "\n" );
+		return implode( "\n", $message );
 	}
 
 	/**

--- a/src/messages/Whip_UpgradePhpMessage.php
+++ b/src/messages/Whip_UpgradePhpMessage.php
@@ -81,6 +81,6 @@ class Whip_UpgradePhpMessage implements Whip_Message {
 			);
 		}
 
-		return implode( $message, "\n" );
+		return implode( "\n", $message );
 	}
 }


### PR DESCRIPTION
`implode()` takes two parameters, `$glue` and `$pieces`.
For historical reasons, `implode()` accepted these parameters in either order, though it was recommended to use the documented argument order of `implode( $glue, $pieces )`.

PHP 7.4 deprecates the tolerance for passing the parameters for `implode()` in reverse order.
PHP 8.0 is expected to remove the tolerance for this completely.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix
* https://php.net/manual/en/function.implode.php

## Verifying this fix

I've turned on a build against `master`: https://travis-ci.org/Yoast/whip/jobs/565998239
As you can see, the Travis builds on PHP 7.4 are failing. This is caused by the above issue.

When you look at the Travis output for this PR - https://travis-ci.org/Yoast/whip/jobs/565996627 -, you will see that the PHP 7.4 are passing again.