### PR TITLE
Composer: require YoastCS ^1.3.0 & update ruleset

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -14,8 +14,6 @@
 
 	<file>.</file>
 
-	<exclude-pattern>vendor/*</exclude-pattern>
-
 	<!-- Only check PHP files. -->
 	<arg name="extensions" value="php"/>
 
@@ -25,7 +23,7 @@
 	<!-- Strip the filepaths down to the relevant bit. -->
 	<arg name="basepath" value="./"/>
 
-	<!-- Check up to 8 files simultanously. -->
+	<!-- Check up to 8 files simultaneously. -->
 	<arg name="parallel" value="8"/>
 
 
@@ -36,6 +34,11 @@
 	-->
 
 	<rule ref="Yoast">
+		<!-- Set the minimum supported WP version for all sniff which use it in one go. -->
+		<properties>
+			<property name="minimum_supported_version" type="3.0"/>
+		</properties>
+
 		<!-- Historically, this library has used camelCaps not snakecase for variable and function names. -->
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
 		<exclude name="WordPress.NamingConventions.ValidFunctionName"/>
@@ -56,7 +59,7 @@
 			<!-- Allow for two adjacent capital letters for acronyms. -->
 			<property name="strict" value="false"/>
 		</properties>
-		
+
 		<!-- Exclude WordPress example function. -->
 		<exclude-pattern>/src/facades/wordpress\.php$</exclude-pattern>
 
@@ -70,9 +73,6 @@
 	SNIFF SPECIFIC CONFIGURATION
 	#############################################################################
 	-->
-
-	<!-- Set the minimum supported WP version. This is used by several sniffs. -->
-	<config name="minimum_supported_wp_version" value="3.0"/>
 
 	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
@@ -99,7 +99,8 @@
 	<!-- Textdomain is passed in dynamically which will not work correctly with gettext().
 		 Ticket: https://github.com/Yoast/whip/issues/2 -->
 	<rule ref="WordPress.WP.I18n.NonSingularStringLiteralDomain">
-		<type>warning</type>
+		<exclude-pattern>/src/messages/Whip_HostMessage\.php$</exclude-pattern>
+		<exclude-pattern>/src/messages/Whip_UpgradePhpMessage\.php$</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound">

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ before_install:
 
 install:
 - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.3.29; fi
-- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then composer remove --dev yoast/yoastcs dealerdirect/phpcodesniffer-composer-installer; fi
-- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then composer remove --dev phpunit/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then composer remove --dev --no-update --no-scripts yoast/yoastcs; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then composer remove --dev --no-update --no-scripts phpunit/phpunit; fi
 - composer install --prefer-dist --no-interaction
 - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local --unset; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ script:
 - find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
 - if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then phpunit; else ./vendor/bin/phpunit; fi
 - if [[ "$TRAVIS_PHP_VERSION" != "5.2" ]]; then composer validate --no-check-all; fi
-- if [[ $PHPCS == "1" ]]; then vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
+- if [[ $PHPCS == "1" ]]; then vendor/bin/phpcs; fi

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "phpunit/phpunit": "^3.6.12 || ^4.5 || ^5.7 || ^6.0 || ^7.0",
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^1.2.2"
+        "yoast/yoastcs": "^1.3.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Ruleset updates:
* Remove dependencies related `exclude-pattern`. These are now contained within the YoastCS ruleset as of v1.3.0.
* Set the `minimum_supported_version` via setting a property instead of as a `config` directive.
    As of YoastCS 1.3.0, a default is set in the `Yoast` ruleset. The default in the `Yoast` ruleset at this time is `4.9`.
    As this repo is compatible with and should still support older WP version, we overrule that value with a repo specific one.
* Change the _temporary adjustment_ for the `WordPress.WP.I18n` sniff.
    Up to now, this sniff would show `warning`s instead of `error`s and the build would ignore warnings when determining the pass/fail.
    As of now - until the issue is fixed - this specific I18n issue will be ignored for those files containing it and CS warnings will no longer be tolerated.
* Minor spelling fix in inline documentation.

Travis:
* Remove the tolerance for CS `warning`s.

~~Note: Until PR #88 has been merged, the build for this PR will fail. I will rebase this PR once PR #88 has been merged.~~
~~Scratch that. The issue fixed in PR #88 is detected by a sniff which is not yet in a released PHPCompatibility version, so the build won't break on it yet until the new version of PHPCompatibility has been released.~~

Uh oh.. The new version of PHPCompatibility has been released in the mean time, so, we're back were we started and this PR will need to be rebased once PR #88 has been merged for the build to pass.