### PR TITLE
Travis: PHP 7.4/nightly tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ php:
 - 5.5
 - 5.4
 - "7.4snapshot"
+- "nightly"
 
 matrix:
   fast_finish: true
@@ -30,7 +31,7 @@ matrix:
 
   allow_failures:
     # Allow failures for unstable builds.
-    - php: "7.4snapshot"
+    - php: "nightly"
 
 before_install:
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
@@ -39,12 +40,17 @@ install:
 - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.3.29; fi
 - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then composer remove --dev --no-update --no-scripts yoast/yoastcs; fi
 - if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then composer remove --dev --no-update --no-scripts phpunit/phpunit; fi
-- composer install --prefer-dist --no-interaction
+- if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then composer install --prefer-dist --no-interaction; fi
 - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local --unset; fi
 
 script:
 - echo $TRAVIS_PHP_VERSION
 - find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-- if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then phpunit; else ./vendor/bin/phpunit; fi
-- if [[ "$TRAVIS_PHP_VERSION" != "5.2" ]]; then composer validate --no-check-all; fi
+- |
+  if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then
+    phpunit
+  elif [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then
+    ./vendor/bin/phpunit
+  fi
+- if [[ "$TRAVIS_PHP_VERSION" == "5.3" || "$TRAVIS_PHP_VERSION" == "7.3" ]]; then composer validate --no-check-all; fi
 - if [[ $PHPCS == "1" ]]; then vendor/bin/phpcs; fi


### PR DESCRIPTION
As of now, PHP 7.4 is no longer allowed to fail.

Also adding a build against `nightly` (= PHP 8). For now, this build will only lint the code, not run the unit tests this will need PHPUnit 8/9 and the unit test suite is not (yet) compatible with those versions.