### PR TITLE
PHPCS: Update to YoastCS 2.0.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -34,9 +34,15 @@
 	-->
 
 	<rule ref="Yoast">
-		<!-- Set the minimum supported WP version for all sniff which use it in one go. -->
 		<properties>
+			<!-- Set the minimum supported WP version for all sniff which use it in one go. -->
 			<property name="minimum_supported_version" type="3.0"/>
+
+			<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
+			<property name="prefixes" type="array">
+				<element value="Yoast\WHIP"/>
+				<element value="whip"/>
+			</property>
 		</properties>
 
 		<!-- Historically, this library has used camelCaps not snakecase for variable and function names. -->
@@ -74,18 +80,46 @@
 	#############################################################################
 	-->
 
-	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
-			<!-- Provide the prefixes to look for. -->
-			<property name="prefixes" type="array">
-				<element value="whip"/>
-				<element value="Yoast\WHIP"/>
+			<!-- Treat the "src" directory as the project root for path to namespace translations. -->
+			<property name="src_directory" type="array">
+				<element value="src"/>
 			</property>
 		</properties>
+	</rule>
 
+
+	<!--
+	#############################################################################
+	SELECTIVE EXCLUSIONS
+	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+	#############################################################################
+	-->
+
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<!-- Valid usage: For testing purposes, allow non-prefixed globals. -->
 		<exclude-pattern>/tests/doubles/WPCoreFunctionsMock\.php$</exclude-pattern>
+	</rule>
+
+	<rule ref="Yoast.NamingConventions.ValidHookName.WrongPrefix">
+		<!-- Valid usage: Example code for external users of the module. -->
+		<exclude-pattern>/src/facades/wordpress\.php$</exclude-pattern>
+	</rule>
+
+
+	<!--
+	#############################################################################
+	TEMPORARY TWEAK
+	YoastCS demands short arrays, but the WHIP module still supports PHP 5.2.
+	#############################################################################
+	-->
+
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax">
+		<severity>0</severity>
 	</rule>
 
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "phpunit/phpunit": "^3.6.12 || ^4.5 || ^5.7 || ^6.0 || ^7.0",
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^1.3.0"
+        "yoast/yoastcs": "^2.0.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -48,7 +48,7 @@
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
         ],
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.2-"
         ],
         "fix-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"


### PR DESCRIPTION
This updates the dependency in `composer.json`, as well as the PHPCS ruleset for YoastCS 2.0.0.

Includes leaving the minimum supported PHP version explicitly at PHP 5.2 for this repo.

Ref: https://github.com/Yoast/yoastcs/releases/tag/2.0.0