### PR TITLE
Docs: various tweaks

### DIFF
--- a/src/Whip_Host.php
+++ b/src/Whip_Host.php
@@ -40,7 +40,7 @@ class Whip_Host {
 	 * In a non-WordPress content this function just returns the passed name.
 	 *
 	 * @param string $name The current name of the host.
-	 * @returns string The filtered name of the host.
+	 * @return string The filtered name of the host.
 	 */
 	private static function filterName( $name ) {
 		if ( function_exists( 'apply_filters' ) ) {
@@ -83,7 +83,7 @@ class Whip_Host {
 	/**
 	 * Returns the URL for the hosting page.
 	 *
-	 * @returns string The URL to the hosting overview page.
+	 * @return string The URL to the hosting overview page.
 	 */
 	public static function hostingPageUrl() {
 		$url = 'https://yoa.st/w3';
@@ -96,7 +96,7 @@ class Whip_Host {
 	 * In a non-WordPress context this function just returns a link to the Yoast hosting page.
 	 *
 	 * @param string $url The previous URL.
-	 * @returns string The new URL to the hosting overview page.
+	 * @return string The new URL to the hosting overview page.
 	 */
 	private static function filterHostingPageUrl( $url ) {
 		if ( function_exists( 'apply_filters' ) && apply_filters( self::HOSTING_PAGE_FILTER_KEY, false ) ) {

--- a/src/Whip_VersionRequirement.php
+++ b/src/Whip_VersionRequirement.php
@@ -81,7 +81,7 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	 * @param string $component        The component for this version requirement.
 	 * @param string $comparisonString The comparison string for this version requirement.
 	 *
-	 * @returns Whip_VersionRequirement The parsed version requirement.
+	 * @return Whip_VersionRequirement The parsed version requirement.
 	 */
 	public static function fromCompareString( $component, $comparisonString ) {
 

--- a/src/Whip_VersionRequirement.php
+++ b/src/Whip_VersionRequirement.php
@@ -76,12 +76,12 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	/**
 	 * Creates a new version requirement from a comparison string.
 	 *
-	 * @throws Whip_InvalidVersionComparisonString When an invalid version comparison string is passed.
-	 *
 	 * @param string $component        The component for this version requirement.
 	 * @param string $comparisonString The comparison string for this version requirement.
 	 *
 	 * @return Whip_VersionRequirement The parsed version requirement.
+	 *
+	 * @throws Whip_InvalidVersionComparisonString When an invalid version comparison string is passed.
 	 */
 	public static function fromCompareString( $component, $comparisonString ) {
 

--- a/src/exceptions/Whip_InvalidOperatorType.php
+++ b/src/exceptions/Whip_InvalidOperatorType.php
@@ -13,8 +13,8 @@ class Whip_InvalidOperatorType extends Exception {
 	/**
 	 * InvalidOperatorType constructor.
 	 *
-	 * @param string $value          Invalid operator.
-	 * @param array  $validOperators Valid operators.
+	 * @param string   $value          Invalid operator.
+	 * @param string[] $validOperators Valid operators.
 	 */
 	public function __construct( $value, $validOperators = array( '=', '==', '===', '<', '>', '<=', '>=' ) ) {
 		parent::__construct(

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -43,12 +43,12 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 	 *
 	 * @dataProvider versionNumbersProvider
 	 *
+	 * @covers Whip_MessageDismisser::__construct
+	 * @covers Whip_MessageDismisser::isDismissed
+	 *
 	 * @param int  $savedTime   The saved time.
 	 * @param int  $currentTime The current time.
 	 * @param bool $expected    The expected value.
-	 *
-	 * @covers Whip_MessageDismisser::__construct
-	 * @covers Whip_MessageDismisser::isDismissed
 	 */
 	public function testIsDismissibleWithVersions( $savedTime, $currentTime, $expected ) {
 		$storage = new Whip_DismissStorageMock();

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -61,7 +61,7 @@ class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Provides array with test values.
 	 *
-	 * @return array
+	 * @return array[]
 	 */
 	public function versionNumbersProvider() {
 		return array(

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -133,17 +133,15 @@ class VersionRequirementTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Tests whether fromCompareString() correctly returns the expected variables from a passed string.
 	 *
-	 * @param string $expectation   The expected output string.
-	 * @param string $component     The component for this version requirement.
-	 * @param string $compareString The comparison string for this version requirement.
+	 * @dataProvider dataFromCompareString
 	 *
 	 * @covers Whip_VersionRequirement::component
 	 * @covers Whip_VersionRequirement::version
 	 * @covers Whip_VersionRequirement::operator
 	 *
-	 * @throws Whip_InvalidVersionComparisonString When the $compareString parameter is invalid.
-	 *
-	 * @dataProvider dataFromCompareString
+	 * @param string $expectation   The expected output string.
+	 * @param string $component     The component for this version requirement.
+	 * @param string $compareString The comparison string for this version requirement.
 	 */
 	public function testFromCompareString( $expectation, $component, $compareString ) {
 		$requirement = Whip_VersionRequirement::fromCompareString( $component, $compareString );

--- a/tests/doubles/Whip_DismissStorageMock.php
+++ b/tests/doubles/Whip_DismissStorageMock.php
@@ -22,7 +22,7 @@ class Whip_DismissStorageMock implements Whip_DismissStorage {
 	 *
 	 * @param int $dismissedValue The value to save.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function set( $dismissedValue ) {
 		$this->dismissed = $dismissedValue;


### PR DESCRIPTION
### Docs: improve specificity of array var/param/return types.

### Docs: fix incorrect tags

It's `@return` not `@returns`.

### Docs: fix tag order

... and remove a superfluous `@throws` for a test which doesn't `throw`.

### Docs: use short form types