### PR TITLE
Travis: use 7.4 not snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,19 @@ cache:
     - $HOME/.cache/composer/files
 
 php:
+- 7.3
 - 7.2
 - 7.1
 - 7.0
 - 5.6
 - 5.5
 - 5.4
-- "7.4snapshot"
 - "nightly"
 
 matrix:
   fast_finish: true
   include:
-    - php: 7.3
+    - php: 7.4
       env: PHPCS=1
     - php: 5.2
       dist: precise
@@ -52,5 +52,5 @@ script:
   elif [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then
     ./vendor/bin/phpunit
   fi
-- if [[ "$TRAVIS_PHP_VERSION" == "5.3" || "$TRAVIS_PHP_VERSION" == "7.3" ]]; then composer validate --no-check-all; fi
+- if [[ "$TRAVIS_PHP_VERSION" == "5.3" || "$TRAVIS_PHP_VERSION" == "7.4" ]]; then composer validate --no-check-all; fi
 - if [[ $PHPCS == "1" ]]; then vendor/bin/phpcs; fi


### PR DESCRIPTION
Since mid December, Travis now has a native PHP 7.4 image available.