### PR TITLE
QA: remove unnecessary comparison in return

### DIFF
--- a/src/Whip_RequirementsChecker.php
+++ b/src/Whip_RequirementsChecker.php
@@ -100,7 +100,7 @@ class Whip_RequirementsChecker {
 		$requiredVersion  = $requirement->version();
 
 		if ( in_array( $requirement->operator(), array( '=', '==', '===' ), true ) ) {
-			return ( version_compare( $availableVersion, $requiredVersion ) !== -1 );
+			return version_compare( $availableVersion, $requiredVersion, '>=' );
 		}
 
 		return version_compare( $availableVersion, $requiredVersion, $requirement->operator() );


### PR DESCRIPTION
Further iteration on #93

As `version_compare()` can return boolean when the third parameter is used, there is no need for the compare here anyway.

Ref: https://www.php.net/manual/en/function.version-compare.php#refsect1-function.version-compare-returnvalues