### PR TITLE
Drop support for PHP 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
   include:
     - php: 7.4
       env: PHPCS=1
-    - php: 5.2
-      dist: precise
     - php: 5.3
       dist: precise
 
@@ -37,19 +35,16 @@ before_install:
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
 
 install:
-- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.3.29; fi
-- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then composer remove --dev --no-update --no-scripts yoast/yoastcs; fi
-- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then composer remove --dev --no-update --no-scripts phpunit/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.3.29; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then composer remove --dev --no-update --no-scripts yoast/yoastcs; fi
 - if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then composer install --prefer-dist --no-interaction; fi
-- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local --unset; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local --unset; fi
 
 script:
 - echo $TRAVIS_PHP_VERSION
 - find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
 - |
-  if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then
-    phpunit
-  elif [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then
+  if [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then
     ./vendor/bin/phpunit
   fi
 - if [[ "$TRAVIS_PHP_VERSION" == "5.3" || "$TRAVIS_PHP_VERSION" == "7.4" ]]; then composer validate --no-check-all; fi

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ A WordPress package to nudge users to upgrade their software versions (starting 
 
 The following versions of PHP are supported:
 
-* PHP 5.2
 * PHP 5.3
 * PHP 5.4
 * PHP 5.5
 * PHP 5.6
 * PHP 7.0
 * PHP 7.1
+* PHP 7.2
+* PHP 7.3
+* PHP 7.4
 
 WordPress is also required for certain functionality:
 
@@ -35,7 +37,7 @@ whip_wp_check_versions( array(
 ) );
 ```
 
-This will show a message to all users of your plugin on PHP5.2 to PHP 5.5. By default the message will be shown on every page of the admin and to every user. It is up to the implementing plugin to restrict this to certain users and/or pages.
+This will show a message to all users of your plugin on PHP 5.3 to PHP 5.5. By default the message will be shown on every page of the admin and to every user. It is up to the implementing plugin to restrict this to certain users and/or pages.
 
 ### Adding a message as a host
 

--- a/composer.json
+++ b/composer.json
@@ -23,32 +23,22 @@
         ]
     },
     "require": {
-        "php": ">=5.2",
-        "xrstf/composer-php52": "^1.0"
+        "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^3.6.12 || ^4.5 || ^5.7 || ^6.0 || ^7.0",
+        "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0",
         "roave/security-advisories": "dev-master",
         "yoast/yoastcs": "^2.0.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "post-install-cmd": [
-            "xrstf\\Composer52\\Generator::onPostInstallCmd"
-        ],
-        "post-update-cmd": [
-            "xrstf\\Composer52\\Generator::onPostInstallCmd"
-        ],
-        "post-autoload-dump": [
-            "xrstf\\Composer52\\Generator::onPostInstallCmd"
-        ],
         "config-yoastcs" : [
             "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
         ],
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.2-"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.3-"
         ],
         "fix-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,8 +21,8 @@ if ( class_exists( 'PHPUnit\Framework\TestCase' ) === true
 	class_alias( 'PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase' );
 }
 
-if ( file_exists( dirname( __FILE__ ) . '/../vendor/autoload_52.php' ) ) {
-	require_once dirname( __FILE__ ) . '/../vendor/autoload_52.php';
+if ( file_exists( dirname( __FILE__ ) . '/../vendor/autoload.php' ) ) {
+	require_once dirname( __FILE__ ) . '/../vendor/autoload.php';
 }
 else {
 	echo 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.' . PHP_EOL;


### PR DESCRIPTION
:warning: **Changelog entry needed** :warning: 

Composer:
* Remove the `xrstf/composer-php52` Composer plugin and the associated scripts.
* Set the minimum supported PHP version to 5.3, including for the PHPCS run.

Travis:
* Drop build on PHP 5.2 and remove associated conditions.

Readme:
* Update the list of supported versions.