### PR TITLE
Travis: use the Composer PHPCS script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ script:
     ./vendor/bin/phpunit
   fi
 - if [[ "$TRAVIS_PHP_VERSION" == "5.3" || "$TRAVIS_PHP_VERSION" == "7.4" ]]; then composer validate --no-check-all; fi
-- if [[ $PHPCS == "1" ]]; then vendor/bin/phpcs; fi
+- if [[ $PHPCS == "1" ]]; then composer check-cs; fi


### PR DESCRIPTION
.. to make sure that the command doesn't need to be updated in two places if anything changes.

**Note**: in this case, it was already problematic as the Composer script - correctly - overrules the supported PHP versions to be used with the PHPCompatibility standard, while the command in the Travis script did not and therefore wasn't checking the codebase for compatibility with PHP 5.3-5.5.

Luckily no issues were introduced in the mean time...