### PR TITLE
Travis/Composer: switch over to parallel linting of PHP files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,28 @@ before_install:
 
 install:
 - if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.3.29; fi
-- if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then composer remove --dev --no-update --no-scripts yoast/yoastcs; fi
-- if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then composer install --prefer-dist --no-interaction; fi
+# Remove "dev" packages which will not install on PHP 5.3.
+- |
+  if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then
+    composer remove --dev --no-update --no-scripts php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter yoast/yoastcs
+  fi
+# Remove "dev" packages which will not install/are not needed on PHP 8.0/nightly.
+- |
+  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    composer remove --dev --no-update --no-scripts yoast/yoastcs phpunit/phpunit
+  fi
+- composer install --prefer-dist --no-interaction
 - if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local --unset; fi
 
 script:
 - echo $TRAVIS_PHP_VERSION
-- find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+- |
+  if [[ $TRAVIS_PHP_VERSION != "5.3" ]]; then
+    composer lint
+  else
+    # PHP Parallel Lint does not support PHP < 5.4...
+    find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+  fi
 - |
   if [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then
     ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,16 @@
     "require-dev": {
         "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0",
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^2.0.0"
+        "yoast/yoastcs": "^2.0.0",
+        "php-parallel-lint/php-parallel-lint": "^1.2",
+        "php-parallel-lint/php-console-highlighter": "^0.5"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
+        "lint": [
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+        ],
         "config-yoastcs" : [
             "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"


### PR DESCRIPTION
Travis/Composer: switch over to parallel linting of PHP files

## Composer

This installs two additional PHP packages in `require-dev`:
* [`php-parallel-lint`](https://packagist.org/packages/jakub-onderka/php-parallel-lint) which allows for linting PHP files in parallel (faster), as well as automatically recursively walking directories.
* [`php-console-highlighter`](https://packagist.org/packages/jakub-onderka/php-console-highlighter) which provides PHP code highlighting in the command line console, allowing the linter to display the results in a more meaningful manner.

It also adds a new `lint` script for use with Composer.

## Travis

* Switch out the script part in the Travis script which did the linting the "old-fashioned" way to use the new Parallel linting option for PHP 5.4+.
    As PHP Parallel Lint has a minimum requirement of PHP 5.4 and this repo still supports PHP 5.3, the old command still needs to remain, but just and only for PHP 5.3.
* Adjust the `composer install` command in the `install` section to always run.
* Tweak what Composer will install for PHP 5.3 and `nightly` as not all packages support those versions (yet for PHP 8).
* Adjusted the `if` statements a little for readability.

Ref:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.2.0
* https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases/tag/v0.5

## Testing this PR

* Check out this branch.
* Run `composer update`.
    If this command gives you any trouble, throw away the `vendor` directory and the `composer.lock` file and run `composer install`.
* Run `composer lint` & see it in action.
* Introduce a parse error in one of the files.
* Run `composer lint` & see the error being reported.
* Undo the parse error.

Also check a couple of the Travis builds to verify that the linting is running and passing.