### PR TITLE
Travis: change from "trusty" to "xenial"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+os: linux
 language: php
-dist: trusty
 
 ## Cache composer downloads.
 cache:
@@ -14,17 +14,21 @@ php:
 - 7.3
 - 7.2
 - 7.1
-- 7.0
-- 5.6
-- 5.5
-- 5.4
 - "nightly"
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - php: 7.4
       env: PHPCS=1
+    - php: 7.0
+      dist: xenial
+    - php: 5.6
+      dist: xenial
+    - php: 5.5
+      dist: trusty
+    - php: 5.4
+      dist: trusty
     - php: 5.3
       dist: precise
 


### PR DESCRIPTION
As the "trusty" environment is no longer officially supported by Travis, they decided in their wisdom to silently stop updating the PHP "nightly" image, which makes it next to useless as the last image apparently is from January....

This updates the Travis config to:
* Removes the global `dist` key, which will let Travis use the default (`xenial`).
* Sets the distro for low PHP versions explicitly as WHIP is expected to still support lower PHP versions for the foreseeable future.
* Makes the expected OS explicit (linux).
* Updates the `matrix` key to `jobs`, which is the canonical for which `matrix` is an alias.