### PR TITLE
Tests: make the testsuite compatible with PHPUnit 9 and test against PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 phpcs.xml
 .cache/phpcs.cache
 phpunit.xml
+.phpunit.result.cache

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -46,6 +46,13 @@
 				<element value="Yoast\WHIP"/>
 				<element value="whip"/>
 			</property>
+
+			<!-- Set the custom test class whitelist for all sniffs which use it in one go.
+				 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes
+			-->
+			<property name="custom_test_class_whitelist" type="array">
+				<element value="Whip_TestCase"/>
+			</property>
 		</properties>
 
 		<!-- Historically, this library has used camelCaps not snakecase for variable and function names. -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,10 @@ install:
 # Remove "dev" packages which will not install on PHP 5.3.
 - |
   if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then
-    composer remove --dev --no-update --no-scripts php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter yoast/yoastcs
+    travis_retry composer remove --dev --no-update --no-scripts php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter yoast/yoastcs
   fi
 # Remove "dev" packages which will not install/are not needed on PHP 8.0/nightly.
-- |
-  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
-    composer remove --dev --no-update --no-scripts yoast/yoastcs phpunit/phpunit
-  fi
-- composer install --prefer-dist --no-interaction
+- travis_retry composer install --no-interaction
 - if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local --unset; fi
 
 script:
@@ -63,9 +59,6 @@ script:
     # PHP Parallel Lint does not support PHP < 5.4...
     find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
   fi
-- |
-  if [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then
-    ./vendor/bin/phpunit
-  fi
+- ./vendor/bin/phpunit
 - if [[ "$TRAVIS_PHP_VERSION" == "5.3" || "$TRAVIS_PHP_VERSION" == "7.4" ]]; then composer validate --no-check-all; fi
 - if [[ $PHPCS == "1" ]]; then composer check-cs; fi

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0",
+        "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "roave/security-advisories": "dev-master",
         "yoast/yoastcs": "^2.0.0",
         "php-parallel-lint/php-parallel-lint": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,11 @@
             "src/"
         ]
     },
+    "autoload-dev": {
+        "classmap": [
+            "tests/"
+        ]
+    },
     "require": {
         "php": ">=5.3"
     },

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -13,12 +13,11 @@ class ConfigurationTest extends Whip_TestCase {
 	/**
 	 * Tests the creation of a Whip_Configuration with invalid input.
 	 *
-	 * @expectedException        Whip_InvalidType
-	 * @expectedExceptionMessage Configuration should be of type array. Found string.
-	 *
 	 * @covers Whip_Configuration::__construct
 	 */
 	public function testItThrowsAnErrorIfAFaultyConfigurationIsPassed() {
+		$this->expectExceptionHelper( 'Whip_InvalidType', 'Configuration should be of type array. Found string.' );
+
 		$configuration = new Whip_Configuration( 'Invalid configuration' );
 	}
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -8,7 +8,7 @@
 /**
  * Configuration unit tests.
  */
-class ConfigurationTest extends PHPUnit_Framework_TestCase {
+class ConfigurationTest extends Whip_TestCase {
 
 	/**
 	 * Tests the creation of a Whip_Configuration with invalid input.

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -8,7 +8,7 @@
 /**
  * Message Dismisser unit tests.
  */
-class MessageDismisserTest extends PHPUnit_Framework_TestCase {
+class MessageDismisserTest extends Whip_TestCase {
 
 	/**
 	 * Tests if Whip_MessageDismisser correctly updates Whip_DismissStorage.

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -11,16 +11,6 @@
 class MessageDismisserTest extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * Instantiates our test class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		require_once dirname( __FILE__ ) . '/doubles/Whip_DismissStorageMock.php';
-		require_once dirname( __FILE__ ) . '/doubles/WPCoreFunctionsMock.php';
-	}
-
-	/**
 	 * Tests if Whip_MessageDismisser correctly updates Whip_DismissStorage.
 	 *
 	 * @covers Whip_MessageDismisser::__construct

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -8,7 +8,7 @@
 /**
  * Message Unit tests.
  */
-class MessageTest extends PHPUnit_Framework_TestCase {
+class MessageTest extends Whip_TestCase {
 
 	/**
 	 * Tests if Whip_BasicMessage correctly handles a string for its body argument.

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -24,24 +24,22 @@ class MessageTest extends Whip_TestCase {
 	/**
 	 * Tests if an Exception is correctly thrown when an empty string is passed as argument.
 	 *
-	 * @expectedException        Whip_EmptyProperty
-	 * @expectedExceptionMessage Message body cannot be empty.
-	 *
 	 * @covers Whip_BasicMessage::validateParameters
 	 */
 	public function testMessageCannotBeEmpty() {
+		$this->expectExceptionHelper( 'Whip_EmptyProperty', 'Message body cannot be empty.' );
+
 		new Whip_BasicMessage( '' );
 	}
 
 	/**
 	 * Tests if an Exception is correctly thrown when an invalid type is passed as argument.
 	 *
-	 * @expectedException        Whip_InvalidType
-	 * @expectedExceptionMessage Message body should be of type string. Found integer.
-	 *
 	 * @covers Whip_BasicMessage::validateParameters
 	 */
 	public function testMessageMustBeString() {
+		$this->expectExceptionHelper( 'Whip_InvalidType', 'Message body should be of type string. Found integer.' );
+
 		new Whip_BasicMessage( 123 );
 	}
 }

--- a/tests/MessagesManagerTest.php
+++ b/tests/MessagesManagerTest.php
@@ -8,7 +8,7 @@
 /**
  * Message Manager unit tests.
  */
-class MessagesManagerTest extends PHPUnit_Framework_TestCase {
+class MessagesManagerTest extends Whip_TestCase {
 
 	/**
 	 * Creates a MessagesManager, calls hasMessages and tests if it returns false

--- a/tests/RequirementsCheckerTest.php
+++ b/tests/RequirementsCheckerTest.php
@@ -8,7 +8,7 @@
 /**
  * Requirements checker unit tests.
  */
-class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
+class RequirementsCheckerTest extends Whip_TestCase {
 
 	/**
 	 * Tests if Whip_RequirementsChecker is successfully created when given valid arguments.

--- a/tests/RequirementsCheckerTest.php
+++ b/tests/RequirementsCheckerTest.php
@@ -130,7 +130,15 @@ class RequirementsCheckerTest extends Whip_TestCase {
 		$recentMessage = $checker->getMostRecentMessage();
 
 		$this->assertNotEmpty( $recentMessage );
-		$this->assertInternalType( 'string', $recentMessage->body() );
+
+		if ( method_exists( $this, 'assertIsString' ) ) {
+			// PHPUnit 8+.
+			$this->assertIsString( $recentMessage->body() );
+		}
+		else {
+			$this->assertInternalType( 'string', $recentMessage->body() );
+		}
+
 		$this->assertFalse( $checker->hasMessages() );
 		$this->assertInstanceOf( 'Whip_UpgradePhpMessage', $recentMessage );
 	}

--- a/tests/RequirementsCheckerTest.php
+++ b/tests/RequirementsCheckerTest.php
@@ -11,15 +11,6 @@
 class RequirementsCheckerTest extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * Set up the class by requiring the WP Core functions mock.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		require_once dirname( __FILE__ ) . '/doubles/WPCoreFunctionsMock.php';
-	}
-
-	/**
 	 * Tests if Whip_RequirementsChecker is successfully created when given valid arguments.
 	 *
 	 * @covers Whip_RequirementsChecker::addRequirement

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * WHIP libary test file.
+ *
+ * @package Yoast\WHIP
+ */
+
+/**
+ * Base test case class from which all tests should extend.
+ */
+class Whip_TestCase extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * Helper method to test exceptions.
+	 *
+	 * PHPUnit 4 contained the `setExpectedException()` method which could test various
+	 * aspects of exceptions.
+	 * PHPUnit 5 introduced a new set of methods to test exceptions, splitting the previous
+	 * functionality up.
+	 * Aside from that PHPUnit has the `@expectException...` annotations, but support for
+	 * those is deprecated in PHPUnit 8 and removed in PHPUnit 9.
+	 *
+	 * All in all, a helper method is needed to allow for testing exceptions in a PHPUnit
+	 * cross-version compatible manner.
+	 *
+	 * @param string          $exception The class name of the exception to expect.
+	 * @param string|null     $message   Optional. The exception message to expect.
+	 * @param int|string|null $code      Optional. The exception code to expect.
+	 *
+	 * @return void
+	 */
+	public function expectExceptionHelper( $exception, $message = '', $code = null ) {
+		if ( method_exists( $this, 'expectException' ) ) {
+			// PHPUnit 5+.
+			$this->expectException( $exception );
+
+			if ( $message !== '' ) {
+				$this->expectExceptionMessage( $message );
+			}
+
+			if ( isset( $code ) ) {
+				$this->expectExceptionCode( $code );
+			}
+		}
+		else {
+			// PHPUnit 4.
+			$this->setExpectedException( $exception, $message, $code );
+		}
+	}
+}

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -8,7 +8,7 @@
 /**
  * Version requirements unit tests.
  */
-class VersionRequirementTest extends PHPUnit_Framework_TestCase {
+class VersionRequirementTest extends Whip_TestCase {
 
 	/**
 	 * Creates a new Whip_VersionRequirement with component php and version 5.2 and

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -29,11 +29,10 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with an empty component.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
-	 *
-	 * @expectedException        Whip_EmptyProperty
-	 * @expectedExceptionMessage Component cannot be empty.
 	 */
 	public function testComponentCannotBeEmpty() {
+		$this->expectExceptionHelper( 'Whip_EmptyProperty', 'Component cannot be empty.' );
+
 		new Whip_VersionRequirement( '', '5.2' );
 	}
 
@@ -42,11 +41,10 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with an empty version.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
-	 *
-	 * @expectedException        Whip_EmptyProperty
-	 * @expectedExceptionMessage Version cannot be empty.
 	 */
 	public function testVersionCannotBeEmpty() {
+		$this->expectExceptionHelper( 'Whip_EmptyProperty', 'Version cannot be empty.' );
+
 		new Whip_VersionRequirement( 'php', '' );
 	}
 
@@ -55,11 +53,10 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with a false type for a component.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
-	 *
-	 * @expectedException        Whip_InvalidType
-	 * @expectedExceptionMessage Component should be of type string. Found integer.
 	 */
 	public function testComponentMustBeString() {
+		$this->expectExceptionHelper( 'Whip_InvalidType', 'Component should be of type string. Found integer.' );
+
 		new Whip_VersionRequirement( 123, '5.2' );
 	}
 
@@ -68,11 +65,10 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with a false type for a version.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
-	 *
-	 * @expectedException        Whip_InvalidType
-	 * @expectedExceptionMessage Version should be of type string. Found integer.
 	 */
 	public function testVersionMustBeString() {
+		$this->expectExceptionHelper( 'Whip_InvalidType', 'Version should be of type string. Found integer.' );
+
 		new Whip_VersionRequirement( 'php', 123 );
 	}
 
@@ -81,11 +77,10 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with an empty operator.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
-	 *
-	 * @expectedException        Whip_EmptyProperty
-	 * @expectedExceptionMessage Operator cannot be empty.
 	 */
 	public function testOperatorCannotBeEmpty() {
+		$this->expectExceptionHelper( 'Whip_EmptyProperty', 'Operator cannot be empty.' );
+
 		new Whip_VersionRequirement( 'php', '5.6', '' );
 	}
 
@@ -94,11 +89,10 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with a false type for an operator.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
-	 *
-	 * @expectedException        Whip_InvalidType
-	 * @expectedExceptionMessage Operator should be of type string. Found integer.
 	 */
 	public function testOperatorMustBeString() {
+		$this->expectExceptionHelper( 'Whip_InvalidType', 'Operator should be of type string. Found integer.' );
+
 		new Whip_VersionRequirement( 'php', '5.2', 6 );
 	}
 
@@ -107,11 +101,13 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with an invalid operator.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
-	 *
-	 * @expectedException        Whip_InvalidOperatorType
-	 * @expectedExceptionMessage Invalid operator of -> used. Please use one of the following operators: =, ==, ===, <, >, <=, >=
 	 */
 	public function testOperatorMustBeValid() {
+		$this->expectExceptionHelper(
+			'Whip_InvalidOperatorType',
+			'Invalid operator of -> used. Please use one of the following operators: =, ==, ===, <, >, <=, >='
+		);
+
 		new Whip_VersionRequirement( 'php', '5.2', '->' );
 	}
 
@@ -172,11 +168,13 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * with an invalid comparison string.
 	 *
 	 * @covers Whip_VersionRequirement::fromCompareString
-	 *
-	 * @expectedException        Whip_InvalidVersionComparisonString
-	 * @expectedExceptionMessage Invalid version comparison string. Example of a valid version comparison string: >=5.3. Passed version comparison string: > 2.3
 	 */
 	public function testFromCompareStringException() {
+		$this->expectExceptionHelper(
+			'Whip_InvalidVersionComparisonString',
+			'Invalid version comparison string. Example of a valid version comparison string: >=5.3. Passed version comparison string: > 2.3'
+		);
+
 		Whip_VersionRequirement::fromCompareString( 'php', '> 2.3' );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,3 +28,5 @@ else {
 	echo 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.' . PHP_EOL;
 	exit( 1 );
 }
+
+require_once dirname( __FILE__ ) . '/doubles/WPCoreFunctionsMock.php';


### PR DESCRIPTION
**TL;DR**: The tests will now be run against PHP 8 and are currently passing.

---

### Tests: autoload test files via Composer

The Composer `autoload-dev` directive allows for specifying files which should only be autoloadable in a `dev` environment.

By adding this directive to the `composer.json` file, we can get rid of most `require_once` statements in the test suite.

The only one remaining is the loading of the WP Core functions mocks. This could be done via a `files` directive within `autoload-dev`, but then they would always be loaded, while they are only needed in the context of running the tests.

So instead, I've added the `require` for the WP Core functions mock file to the test `bootstrap` file.

A side-effect of this change is that we can get rid of the `setUpBeforeClass()` methods which are problematic for PHPUnit cross-version compatibility due to the addition of the `void` return type to the method signature in PHPUnit 8.

### Tests: add base TestCase

To make the tests cross-version compatible for the WHIP module, not that much is needed in terms of compatibility polyfills.

The most pertinent issue is to do with testing exceptions.

This commit adds a base `TestCase` from which all WHIP test classes will extend from now on. This `TestCase` class only contains a helper method to test exceptions in a PHPUnit cross-version compatible manner.

Includes adding the new testCase to the PHPCS ruleset so sniffs which behave differently in test situations will recognize these correctly.

### Tests: implement use of the `TestCase::expectExceptionHelper()` method

.. to replace the `@expectedException...` annotations which have been removed in PHPUnit 9.

### Tests: implement work-around for remaining PHPUnit cross-version issue

PHPUnit 9 removed the `assertInternalType()` method in favour of more specific methods, which were introduced in PHPUnit 8.

As this test suite only uses this assertion in one place, putting a polyfill in place is over the top. A simple if/else does the trick.

### Composer: allow installation of PHPUnit 8 and 9

Now the tests have been made cross-version compatible with PHPUnit 8 and 9, allow installation of those versions by widening the version restraints in the `composer.json` file.

PHPUnit 8 introduces a form of caching to PHPUnit, so adding this cache file to the `.gitignore` file.

### Travis: run the tests against PHP 8/nightly

Now the tests are fully compatible with PHPUnit 9, the test suite can be run on PHP 8.

~~As not all dependencies of PHPUnit have tagged a new version which allows for PHP 8 yet, we do need to `ignore-platform-reqs` for the time being.~~

Includes adding `travis_retry` to `composer install`-like commands to get round builds stalling on the connection with Packagist, especially on older PHP versions.

