### PR TITLE
Travis: add a build against PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
     - $HOME/.cache/composer/files
 
 php:
+- 8.0
 - 7.3
 - 7.2
 - 7.1


### PR DESCRIPTION
Since this Friday, Travis now has a PHP 8.0 image available.

This commit adds a new build against PHP 8.0, which is not allowed to fail.