### PR TITLE
Composer: update PHP Parallel Lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
 # Remove "dev" packages which will not install on PHP 5.3.
 - |
   if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then
-    travis_retry composer remove --dev --no-update --no-scripts php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter yoast/yoastcs
+    travis_retry composer remove --dev --no-update --no-scripts php-parallel-lint/php-console-highlighter yoast/yoastcs
   fi
 # Remove "dev" packages which will not install/are not needed on PHP 8.0/nightly.
 - travis_retry composer install --no-interaction
@@ -53,13 +53,7 @@ install:
 
 script:
 - echo $TRAVIS_PHP_VERSION
-- |
-  if [[ $TRAVIS_PHP_VERSION != "5.3" ]]; then
-    composer lint
-  else
-    # PHP Parallel Lint does not support PHP < 5.4...
-    find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-  fi
+- composer lint
 - ./vendor/bin/phpunit
 - if [[ "$TRAVIS_PHP_VERSION" == "5.3" || "$TRAVIS_PHP_VERSION" == "7.4" ]]; then composer validate --no-check-all; fi
 - if [[ $PHPCS == "1" ]]; then composer check-cs; fi

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "roave/security-advisories": "dev-master",
         "yoast/yoastcs": "^2.1.0",
-        "php-parallel-lint/php-parallel-lint": "^1.2",
+        "php-parallel-lint/php-parallel-lint": "^1.3",
         "php-parallel-lint/php-console-highlighter": "^0.5"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Update version constraint for PHP Parallel Lint after new release.

The most significant change in this release is that PHP Parallel Lint now also supports PHP 5.3. This allows us to make some simplifications to the Travis script as we, for the most part, no longer need to special case PHP 5.3.

Refs:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.3.0