### PR TITLE
Whip_WPMessagePresenter: prevent BC-break

### DIFF
--- a/src/presenters/Whip_WPMessagePresenter.php
+++ b/src/presenters/Whip_WPMessagePresenter.php
@@ -54,6 +54,18 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 	}
 
 	/**
+	 * Registers hooks to WordPress.
+	 *
+	 * @deprecated 1.2.0 Use the Whip_WPMessagePresenter::registerHooks() method instead.
+	 * @codeCoverageIgnore
+	 * @phpcs:disable Generic.NamingConventions.CamelCapsFunctionName
+	 */
+	public function register_hooks() {
+		// phpcs:enable
+		self::registerHooks();
+	}
+
+	/**
 	 * Renders the messages present in the global to notices.
 	 */
 	public function renderMessage() {


### PR DESCRIPTION
[Per the Readme](https://github.com/Yoast/whip#backwards-compatibility-policy) - semantic versioning is strictly adhered to.

PR #52 introduced a - albeit minor - BC-break due to renaming the `public` `Whip_WPMessagePresenter::register_hooks()` method to `Whip_WPMessagePresenter::registerHooks()`.

While in practice, the BC-break is probably theoretical, the BC-break should still be mitigated if the next release is to be in the 1.x series and not 2.0.