### PR TITLE
Changelog: prepare for the release of version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.0.1]
+## [1.0.2] - 2017-06-27
+### Fixed
+* When multiple plugins containing whip are activated, the message is no longer shown multiple times, props [Andrea](https://github.com/sciamannikoo).
+
+## [1.0.1] - 2017-03-21
 ### Fixed
 * Fix a missing link when the PHP message is switched to the WordPress.org hosting page.
 
-## [1.0.0]
+## [1.0.0] - 2017-03-21
 ### Changed
 * Updated screenshot in README
 
@@ -26,7 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.0.0-beta.1 - 2017-02-21
 * Initial pre-release of whip. A package to nudge users to upgrade their software versions.
 
-[Unreleased]: https://github.com/yoast/whip/compare/1.0.1...HEAD
+[Unreleased]: https://github.com/yoast/whip/compare/1.0.2...HEAD
+[1.0.2]: https://github.com/yoast/whip/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/yoast/whip/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/yoast/whip/compare/1.0.0-beta.2...1.0.0
 [1.0.0-beta.2]: https://github.com/yoast/whip/compare/1.0.0-beta.1...1.0.0-beta.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0] - 2017-08-08
+### Added
+* Allow WordPress messages to be dismissed for a period of 4 weeks.
+
 ## [1.0.2] - 2017-06-27
 ### Fixed
 * When multiple plugins containing whip are activated, the message is no longer shown multiple times, props [Andrea](https://github.com/sciamannikoo).
@@ -30,7 +34,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.0.0-beta.1 - 2017-02-21
 * Initial pre-release of whip. A package to nudge users to upgrade their software versions.
 
-[Unreleased]: https://github.com/yoast/whip/compare/1.0.2...HEAD
+[Unreleased]: https://github.com/yoast/whip/compare/1.1.0...HEAD
+[1.1.0]: https://github.com/yoast/whip/compare/1.0.2...1.1.0
 [1.0.2]: https://github.com/yoast/whip/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/yoast/whip/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/yoast/whip/compare/1.0.0-beta.2...1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0] - 2021-07-19
+
+:warning: This version drops support for PHP 5.2!
+
+### Changed
+* PHP 5.2 is no longer supported. The minimum supported PHP version for the WHIP library is now PHP 5.3. [#96]
+* The previous solution to prevent duplicate messages as included in v1.0.2 has been improved upon and made more stable. Props [Drew Jaynes]. [#44]
+* The `Whip_InvalidOperatorType::__construct()` method now has a second, optional `$validOperators` parameter. [#62]
+    If this parameter is not passed, the default set of valid operators, as was used before, will be used.
+* Improved protection against XSS in localizable texts. [#50]
+* Improved support for translating localizable texts (I18n). [#59]
+* The distributed package will no longer contain development-related files. [#45]
+* General housekeeping.
+
+### Deprecated
+* The `public` `Whip_WPMessagePresenter:register_hooks()` method has been deprecated in favour of the new `Whip_WPMessagePresenter:registerHooks()`. [#52], [#107]
+
+### Fixed
+* The text of the exception message thrown via the `Whip_InvalidType` exception was sometimes garbled. [#61]
+* Compatibility with PHP >= 7.4: prevent a deprecation notice from being thrown (fatal error on PHP 8.0). [#88]
+
+[#44]:  https://github.com/Yoast/whip/pull/44
+[#45]:  https://github.com/Yoast/whip/pull/45
+[#50]:  https://github.com/Yoast/whip/pull/50
+[#52]:  https://github.com/Yoast/whip/pull/52
+[#59]:  https://github.com/Yoast/whip/pull/59
+[#61]:  https://github.com/Yoast/whip/pull/61
+[#62]:  https://github.com/Yoast/whip/pull/62
+[#88]:  https://github.com/Yoast/whip/pull/88
+[#96]:  https://github.com/Yoast/whip/pull/96
+[#107]: https://github.com/Yoast/whip/pull/107
+
+[Drew Jaynes]: https://github.com/DrewAPicture
+
 ## [1.1.0] - 2017-08-08
 ### Added
 * Allow WordPress messages to be dismissed for a period of 4 weeks.
@@ -34,7 +68,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.0.0-beta.1 - 2017-02-21
 * Initial pre-release of whip. A package to nudge users to upgrade their software versions.
 
-[Unreleased]: https://github.com/yoast/whip/compare/1.1.0...HEAD
+[Unreleased]: https://github.com/yoast/whip/compare/1.2.0...HEAD
+[1.2.0]: https://github.com/yoast/whip/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/yoast/whip/compare/1.0.2...1.1.0
 [1.0.2]: https://github.com/yoast/whip/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/yoast/whip/compare/1.0.0...1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,5 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.0.0-beta.1 - 2017-02-21
 * Initial pre-release of whip. A package to nudge users to upgrade their software versions.
 
-[Unreleased]: https://github.com/yoast/whip/compare/1.0.0-beta.2...HEAD
+[Unreleased]: https://github.com/yoast/whip/compare/1.0.1...HEAD
+[1.0.1]: https://github.com/yoast/whip/compare/1.0.0...1.0.1
+[1.0.0]: https://github.com/yoast/whip/compare/1.0.0-beta.2...1.0.0
 [1.0.0-beta.2]: https://github.com/yoast/whip/compare/1.0.0-beta.1...1.0.0-beta.2


### PR DESCRIPTION
ℹ️  Note: this PR is in draft as PR #107 still needs to be merged and included in the 1.2.0 release.

---

### Changelog: add missing version compare links

### Changelog: import changelog for v 1.0.2

The changelog for v 1.0.2 only existed in the 1.0.2 tag.

Includes adding dates to undated release entries.

Ref:
* ddd1e0e
* e9df81e

### Changelog: import changelog for v 1.1.0

The changelog for v 1.1.0 only existed in the 1.1.0 tag.

Ref:
* 1ea57a0
* 2fc9da3
* f66106f

### Changelog: add changelog for the 1.2.0 release 

The release date has been tentatively set to next **Monday, July 19, 2021**.