### PR TITLE
Composer: update to YoastCS 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ install:
 # Remove "dev" packages which will not install on PHP 5.3.
 - |
   if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then
-    travis_retry composer remove --dev --no-update --no-scripts php-parallel-lint/php-console-highlighter yoast/yoastcs
+    travis_retry composer remove --dev --no-update --no-scripts yoast/yoastcs
+    travis_retry composer require --dev --no-update --no-scripts php-parallel-lint/php-parallel-lint
   fi
 # Remove "dev" packages which will not install/are not needed on PHP 8.0/nightly.
 - travis_retry composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^2.1.0",
-        "php-parallel-lint/php-parallel-lint": "^1.3",
-        "php-parallel-lint/php-console-highlighter": "^0.5"
+        "yoast/yoastcs": "^2.1.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
... which includes PHP Parallel Lint by design, so no need to require it separately anymore.

For CI on PHP 5.3, this does require a small tweak, but that's nothing exciting.

Ref: https://github.com/Yoast/yoastcs/releases