### PR TITLE
Travis: remove nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ php:
 - 7.3
 - 7.2
 - 7.1
-- "nightly"
 
 jobs:
   fast_finish: true
@@ -33,10 +32,6 @@ jobs:
     - php: 5.3
       dist: precise
 
-  allow_failures:
-    # Allow failures for unstable builds.
-    - php: "nightly"
-
 before_install:
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
 
@@ -48,7 +43,6 @@ install:
     travis_retry composer remove --dev --no-update --no-scripts yoast/yoastcs
     travis_retry composer require --dev --no-update --no-scripts php-parallel-lint/php-parallel-lint
   fi
-# Remove "dev" packages which will not install/are not needed on PHP 8.0/nightly.
 - travis_retry composer install --no-interaction
 - if [[ $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local --unset; fi
 


### PR DESCRIPTION
At this time, the current PHP 8.0 version is `8.0.11`. The Travis PHP `8.0` image yields PHP `8.0.9`, which is good enough for PHP 8.0.

`nightly` however is PHP `8.0.3` and hasn't been updated since Feb 2021, so running tests against that image is completely useless at this time.

Notes:
    * Tested `nightly` against all relevant `dist`s - `xenial`, `bionic` and `focal` and none have a more current image.
    * The [PHP Build project](https://github.com/php-build/php-build/tree/master/share/php-build/definitions), which Travis pulls its images from, _does_ have a PHP `8.1snapshot` image available.
        I've tested to see if that image is available on Travis, but unfortunately, no luck there either.

Includes removing a redundant inline comment in the script.