### PR TITLE
Composer: update to YoastCS 2.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^2.1.0"
+        "yoast/yoastcs": "^2.2.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Follow up on #109, which did do the update, but didn't update the minimum version in the `composer.json`. Fixed now.