### PR TITLE
Allow for passing custom messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,22 @@ $ composer require yoast/whip
 The easiest way to use Whip in WordPress is by using the included function to check the versions. In this case checking if PHP 5.6 or greater is installed: 
 ```php
 whip_wp_check_versions( array(
-	'php' => '>=5.6',
+	'php' => [ 'version' => '>=5.6' ],
 ) );
 ```
 
 This will show a message to all users of your plugin on PHP 5.3 to PHP 5.5. By default the message will be shown on every page of the admin and to every user. It is up to the implementing plugin to restrict this to certain users and/or pages.
+
+### Using custom messages
+To overwrite the default message, you can pass your own:
+```php
+whip_wp_check_versions( array(
+	'php' => [
+	    'version' => '>=5.6',
+	    'message' => new Whip_NullMessage(), // Or any object implementing the Whip_Message interface. 
+	 ],
+) );
+```
 
 ### Adding a message as a host
 

--- a/src/Whip_MessageProvider.php
+++ b/src/Whip_MessageProvider.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WHIP libary file.
+ *
+ * @package Yoast\WHIP
+ */
+
+/**
+ * Provides messages to display when a requirement isn't met.
+ */
+class Whip_MessageProvider {
+
+	/**
+	 * The list of messages that are registered.
+	 *
+	 * @var Whip_Message[]
+	 */
+	private $registeredMessages;
+
+	/**
+	 * Whip_MessageProvider constructor.
+	 */
+	public function __construct() {
+		$this->registeredMessages = array();
+	}
+
+	/**
+	 * Adds a message to the list of messages and overwrites it if it already exists.
+	 *
+	 * @param Whip_Message     $message     The message to register.
+	 * @param Whip_Requirement $requirement The requirement that the message is for.
+	 */
+	public function addMessage( Whip_Message $message, Whip_Requirement $requirement ) {
+		$this->registeredMessages[ $requirement->component() ] = $message;
+	}
+
+	/**
+	 * Gets the message for a given requirement.
+	 *
+	 * @param Whip_Requirement   $requirement   The requirement to get the message for.
+	 * @param Whip_Configuration $configuration The current configuration.
+	 *
+	 * @return Whip_Message
+	 */
+	public function getMessage( Whip_Requirement $requirement, Whip_Configuration $configuration ) {
+		$component = $requirement->component();
+		if ( $this->messageExistsForComponent( $component ) ) {
+			return $this->registeredMessages[ $component ];
+		}
+
+		// Fallback to a generic message.
+		return new Whip_InvalidVersionRequirementMessage( $requirement, $configuration->configuredVersion( $requirement ) );
+	}
+
+	/**
+	 * Determines whether a message exists for a particular component.
+	 *
+	 * @param string $component The component to check for.
+	 *
+	 * @return bool Whether the component has a message defined.
+	 */
+	private function messageExistsForComponent( $component ) {
+		return isset( $this->registeredMessages[ $component ] );
+	}
+}

--- a/src/facades/wordpress.php
+++ b/src/facades/wordpress.php
@@ -17,11 +17,22 @@ if ( ! function_exists( 'whip_wp_check_versions' ) ) {
 			return;
 		}
 
-		$config  = include dirname( __FILE__ ) . '/../configs/default.php';
-		$checker = new Whip_RequirementsChecker( $config );
+		$config = include __DIR__ . '/../configs/default.php';
 
-		foreach ( $requirements as $component => $versionComparison ) {
-			$checker->addRequirement( Whip_VersionRequirement::fromCompareString( $component, $versionComparison ) );
+		$messageProvider    = new Whip_MessageProvider();
+		$requirementObjects = array();
+		foreach ( $requirements as $component => $requirement ) {
+			$requirementObject    = Whip_VersionRequirement::fromCompareString( $component, $requirement['version'] );
+			$requirementObjects[] = $requirementObject;
+			if ( isset( $requirement['message'] ) ) {
+				$messageProvider->addMessage( $requirement['message'], $requirementObject );
+			}
+		}
+
+		$checker = new Whip_RequirementsChecker( new Whip_Configuration( $config ), $messageProvider );
+
+		foreach ( $requirementObjects as $requirement ) {
+			$checker->addRequirement( $requirement );
 		}
 
 		$checker->check();

--- a/src/interfaces/Whip_Requirement.php
+++ b/src/interfaces/Whip_Requirement.php
@@ -16,4 +16,18 @@ interface Whip_Requirement {
 	 * @return string The component name.
 	 */
 	public function component();
+
+	/**
+	 * Gets the component's version defined for the requirement.
+	 *
+	 * @return string
+	 */
+	public function version();
+
+	/**
+	 * Gets the operator to use when comparing version numbers.
+	 *
+	 * @return string The comparison operator.
+	 */
+	public function operator();
 }


### PR DESCRIPTION
WIP: Still need to update tests

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The built-in messaging is very specific for PHP 5.6 which is no longer relevant. Instead of having to release WHIP with a new message for every PHP version, we need to be able to provide a custom message.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add support for customized messages.

## Relevant technical choices:

* BC break: the WordPress fasade now requires an array per component instead of just a version constraint. This is done to match a version requirement to message.
* BC break: I've added version and operator to the WHIP_Requirement interface. The code already relied on these functions. and in the context of WHIP every requirement is a version constraint, so I didn't think adding w WHIL_Version_Requirement. was the way to go.
