### PR TITLE
GH Actions: PHP 8.1 has been released

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     name: "Lint and test: PHP ${{ matrix.php_version }}"
 
     # Allow builds to fail on as-of-yet unreleased PHP versions.
-    continue-on-error: ${{ matrix.php_version == '8.1' || matrix.php_version == '8.2' }}
+    continue-on-error: ${{ matrix.php_version == '8.2' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
... so builds against PHP 8.1 should no longer be allowed to fail.