### PR TITLE
Whip_RequirementsChecker: explicitly declare all properties

### DIFF
--- a/src/Whip_RequirementsChecker.php
+++ b/src/Whip_RequirementsChecker.php
@@ -18,6 +18,20 @@ class Whip_RequirementsChecker {
 	private $requirements;
 
 	/**
+	 * The configuration to check.
+	 *
+	 * @var Whip_Configuration
+	 */
+	private $configuration;
+
+	/**
+	 * Message Manager.
+	 *
+	 * @var Whip_MessagesManager
+	 */
+	private $messageManager;
+
+	/**
 	 * The text domain to use for translations.
 	 *
 	 * @var string


### PR DESCRIPTION
Dynamic (non-explicitly declared) property usage is expected to be deprecated as of PHP 8.2 and will become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

In this case, both the `$configuration` property, as well as the `$messageManager` property (both set in the class constructor) fall in the "known property" category and should be declared.

Note: while this _could_ be considered a BC-break, I've elected to make these properties `private` (was previously automatically `public` due to these being dynamic properties).

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties