### PR TITLE
GH Actions: version update for `ramsey/composer-install`

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -37,7 +37,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       # Check the codestyle of the files.
       # The results of the CS check will be shown inline in the PR via the CS2PR tool.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,18 +42,18 @@ jobs:
       - name: Adjust Composer dependencies (PHP 5.3)
         if: matrix.php_version == '5.3'
         run: |
-          composer remove --dev --no-update --no-scripts yoast/yoastcs
-          composer require --dev --no-update --no-scripts php-parallel-lint/php-parallel-lint
+          composer remove --dev --no-update --no-scripts yoast/yoastcs --no-interaction
+          composer require --dev --no-update --no-scripts php-parallel-lint/php-parallel-lint --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies (PHP < 8.2)
         if: matrix.php_version != '8.2'
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Install Composer dependencies (PHP 8.2)
         if: matrix.php_version == '8.2'
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
         with:
           composer-options: "--ignore-platform-req=php"
 


### PR DESCRIPTION
The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Includes adding `--no-interaction` to "plain" Composer commands to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.

Refs:
* https://github.com/ramsey/composer-install/releases/tag/2.0.0
* https://github.com/ramsey/composer-install/releases/tag/2.0.1
* https://github.com/ramsey/composer-install/releases/tag/2.0.2