### PR TITLE
Tests: use named data providers

### DIFF
--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -55,10 +55,10 @@ class MessageDismisserTest extends Whip_TestCase {
 	 */
 	public function versionNumbersProvider() {
 		return array(
-			array( strtotime( '-2weeks' ), time(), true ),
-			array( strtotime( '-4weeks' ), time(), true ),
-			array( strtotime( '-6weeks' ), time(), false ),
-			array( time(), time(), true ),
+			'-2weeks' => array( strtotime( '-2weeks' ), time(), true ),
+			'-4weeks' => array( strtotime( '-4weeks' ), time(), true ),
+			'-6weeks' => array( strtotime( '-6weeks' ), time(), false ),
+			'time()'  => array( time(), time(), true ),
 		);
 	}
 }

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -152,14 +152,14 @@ class VersionRequirementTest extends Whip_TestCase {
 	 */
 	public function dataFromCompareString() {
 		return array(
-			array( array( 'php', '5.5', '>' ), 'php', '>5.5' ),
-			array( array( 'php', '5.5', '>=' ), 'php', '>=5.5' ),
-			array( array( 'php', '5.5', '<' ), 'php', '<5.5' ),
-			array( array( 'php', '5.5', '<=' ), 'php', '<=5.5' ),
-			array( array( 'php', '7.3', '>' ), 'php', '>7.3' ),
-			array( array( 'php', '7.3', '>=' ), 'php', '>=7.3' ),
-			array( array( 'php', '7.3', '<' ), 'php', '<7.3' ),
-			array( array( 'php', '7.3', '<=' ), 'php', '<=7.3' ),
+			'php > 5.5'  => array( array( 'php', '5.5', '>' ), 'php', '>5.5' ),
+			'php >= 5.5' => array( array( 'php', '5.5', '>=' ), 'php', '>=5.5' ),
+			'php < 5.5'  => array( array( 'php', '5.5', '<' ), 'php', '<5.5' ),
+			'php <= 5.5' => array( array( 'php', '5.5', '<=' ), 'php', '<=5.5' ),
+			'php > 7.3'  => array( array( 'php', '7.3', '>' ), 'php', '>7.3' ),
+			'php >= 7.3' => array( array( 'php', '7.3', '>=' ), 'php', '>=7.3' ),
+			'php < 7.3'  => array( array( 'php', '7.3', '<' ), 'php', '<7.3' ),
+			'php <= 7.3' => array( array( 'php', '7.3', '<=' ), 'php', '<=7.3' ),
 		);
 	}
 


### PR DESCRIPTION
This improves the test descriptiveness when using the `--testdox` option as well as making it easier to identify which data set failed.