### PR TITLE
Composer: update YoastCS and dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^2.2.1"
+        "yoast/yoastcs": "^2.3.0"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
* YoastCS 2.3.0 has been released. Previous version used was `2.2.1`.
    Ref: https://github.com/Yoast/yoastcs/releases/tag/2.3.0
* Version 1.0.0 of the Composer PHPCS plugin has been released. Previous version used was `0.7.2`.
    Ref: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases