### PR TITLE
CI/QA: start recording code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,17 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php_version: ['5.4', '5.5', '5.6', '7.0', '7.2', '7.3', '7.4', '8.0', '8.1']
+        coverage: [false]
+
+        # Run code coverage only on high/medium/low PHP.
+        include:
+        - php_version: 5.3
+          coverage: true
+        - php_version: 7.1
+          coverage: true
+        - php_version: 8.2
+          coverage: true
 
     name: "Lint and test: PHP ${{ matrix.php_version }}"
 
@@ -32,7 +42,7 @@ jobs:
         with:
           php-version: ${{ matrix.php_version }}
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
-          coverage: none
+          coverage: ${{ matrix.coverage == true && 'xdebug' || 'none' }}
           tools: cs2pr
 
       # YoastCS has a minimum PHP requirement of 5.4, so remove it and hard require Parallel Lint.
@@ -54,4 +64,42 @@ jobs:
         run: composer lint -- --checkstyle | cs2pr
 
       - name: Run the unit tests
+        if: ${{ matrix.coverage == false }}
         run: vendor/bin/phpunit
+
+      - name: Run the unit tests with code coverage
+        if: ${{ matrix.coverage == true }}
+        run: composer coverage
+
+      # PHP Coveralls doesn't fully support PHP 8.x yet, so switch the PHP version.
+      # Additionally Coveralls 1.x (which would be needed for PHP < 5.5) doesn't play nice with GH Actions.
+      - name: Switch to PHP 7.4
+        if: ${{ success() && matrix.coverage == true }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
+      - name: Install Coveralls
+        if: ${{ success() && matrix.coverage == true }}
+        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
+
+      - name: Upload coverage results to Coveralls
+        if: ${{ success() && matrix.coverage == true }}
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+          COVERALLS_PARALLEL: true
+          COVERALLS_FLAG_NAME: php-${{ matrix.php_version }}
+        run: php-coveralls -v -x build/logs/clover.xml
+
+  coveralls-finish:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.COVERALLS_TOKEN }}
+          parallel-finished: true

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ phpcs.xml
 .cache/phpcs.cache
 phpunit.xml
 .phpunit.result.cache
+build/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CS](https://github.com/Yoast/whip/actions/workflows/cs.yml/badge.svg)](https://github.com/Yoast/whip/actions/workflows/cs.yml)
 [![Test](https://github.com/Yoast/whip/actions/workflows/test.yml/badge.svg)](https://github.com/Yoast/whip/actions/workflows/test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/Yoast/whip/badge.svg?branch=main)](https://coveralls.io/github/Yoast/whip?branch=main)
 
 # whip
 A WordPress package to nudge users to upgrade their software versions (starting with PHP)

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,9 @@
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
         ],
         "test": [
+            "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+        ],
+        "coverage": [
             "@php ./vendor/phpunit/phpunit/phpunit"
         ]
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,7 @@
 		convertWarningsToExceptions="true"
 		convertNoticesToExceptions="true"
 		convertDeprecationsToExceptions="true"
+		forceCoversAnnotation="true"
 	>
 	<testsuites>
 		<testsuite name="whip">
@@ -16,8 +17,14 @@
 	</testsuites>
 
 	<filter>
-		<whitelist>
-			<directory>./src</directory>
+		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
+			<directory>src/</directory>
 		</whitelist>
 	</filter>
+
+    <logging>
+        <log type="coverage-text" target="php://stdout" showOnlySummary="true"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+
 </phpunit>


### PR DESCRIPTION
This commit makes the necessary changes to start recording and uploading code coverage data to Coveralls.

Includes:
* Updating the GH Actions `test` worflow to run the high/low PHP version builds with code coverage and upload the results.
* Updating the PHPUnit config to show an inline code coverage summary, improve the `filter` configuration and force the use of `@covers` tags.
* Ignoring the potentially generated code coverage files in the `build/*` directory to prevent it being committed.
* Adding a script to the `composer.json` file to run code coverage.
* Adding a code coverage badge to the README.

Notes:
* Coverage will be recorded using `Xdebug` as the code coverage driver.
* Recording code coverage can be slow and it is not needed to run it on each build to still get a good idea of the code coverage. With that in mind, code coverage is only recorded for high/medium/low PHP.
* The `php-coveralls/php-coveralls` package is used to convert the coverage information from a format as generated by PHPUnit to a format as can be consumed by Coveralls. - As this package is only needed for the upload to Coveralls, the package has **not** been added it to the `composer.json` file, but will be (global) installed in the GH Actions workflow only. - The `php-coveralls/php-coveralls` package is not 100% compatible with PHP 8.x (yet), so for uploading the coverage generated using PHP 8.x, we switch to PHP 7.4 for uploading the code coverage reports. - For uploading code coverage with PHP < 5.5, `php-coveralls/php-coveralls` `1.x` is needed, but that version of the package doesn't play nice with GH Actions. To get round that, the job which runs on PHP < 5.5, will switch to PHP 7.4 for uploading the code coverage reports.
* Coveralls requires a token to identify the repo and prevent unauthorized uploads. This token has been added to the repository secrets. People with admin access to the GH repo automatically also have access to the admin settings in Coveralls. If ever needed, the Coveralls token can be found (and regenerated) in the Coveralls admin for a repo. After regeneration, the token as stored in the GH repo Settings -> Secrets and Variables -> Actions -> Repository secrets should be updated.
* As the workflow sends multiple code coverage reports to Coveralls, we need to tell it to process those reports in parallel and give each report a unique name. That's what the `COVERALLS_PARALLEL` and COVERALLS_FLAG_NAME` settings are about.
* The `coveralls-finish` job will signal to Coveralls that all reports have been uploaded. This basically gives the "okay" to Coveralls to report on the changes in code coverage via a comment on a GitHub PR as well as via a status check.

The pertinent Coveralls settings used for this repo are:
* "Only send aggregate Coverage updates to SCM": enabled
* "Leave comments": enabled
* "(Comment) Format": detailed
* "Use Status API": enabled
* "Coverage threshold for failure": 20%
* "Coverage decrease threshold for failure": 1.0%