### PR TITLE
Modernize: use __DIR__ instead of dirname( __FILE__ )

### DIFF
--- a/src/Whip_MessagesManager.php
+++ b/src/Whip_MessagesManager.php
@@ -25,7 +25,7 @@ class Whip_MessagesManager {
 	 * @param Whip_Message $message The message to add.
 	 */
 	public function addMessage( Whip_Message $message ) {
-		$whipVersion = require dirname( __FILE__ ) . '/configs/version.php';
+		$whipVersion = require __DIR__ . '/configs/version.php';
 
 		$GLOBALS['whip_messages'][ $whipVersion ] = $message;
 	}

--- a/src/facades/wordpress.php
+++ b/src/facades/wordpress.php
@@ -17,7 +17,7 @@ if ( ! function_exists( 'whip_wp_check_versions' ) ) {
 			return;
 		}
 
-		$config  = include dirname( __FILE__ ) . '/../configs/default.php';
+		$config  = include __DIR__ . '/../configs/default.php';
 		$checker = new Whip_RequirementsChecker( $config );
 
 		foreach ( $requirements as $component => $versionComparison ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,12 +21,12 @@ if ( class_exists( 'PHPUnit\Framework\TestCase' ) === true
 	class_alias( 'PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase' );
 }
 
-if ( file_exists( dirname( __FILE__ ) . '/../vendor/autoload.php' ) ) {
-	require_once dirname( __FILE__ ) . '/../vendor/autoload.php';
+if ( file_exists( __DIR__ . '/../vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/../vendor/autoload.php';
 }
 else {
 	echo 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.' . PHP_EOL;
 	exit( 1 );
 }
 
-require_once dirname( __FILE__ ) . '/doubles/WPCoreFunctionsMock.php';
+require_once __DIR__ . '/doubles/WPCoreFunctionsMock.php';


### PR DESCRIPTION
As support for PHP < 5.3 has been dropped (in PR #96), the `__DIR__` constant can be safely used.