### PR TITLE
GH Actions: run workflows more selectively

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -1,9 +1,27 @@
 name: CS
 
 on:
-  # Run on all pushes and on all pull requests.
+  # Run on all relevant pushes and on all relevant pull requests.
   push:
+    paths-ignore:
+      - '**.md'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'phpunit.xml.dist'
+      - '.github/dependabot.yml'
+      - '.github/workflows/test.yml'
+      - 'images/**'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'phpunit.xml.dist'
+      - '.github/dependabot.yml'
+      - '.github/workflows/test.yml'
+      - 'images/**'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,31 @@
 name: Test
 
 on:
-  # Run on pushes to `main` and on all pull requests.
+  # Run on relevant pushes to `main` and on all relevant pull requests.
   push:
     branches:
       - main
     paths-ignore:
       - '**.md'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'LICENSE'
+      - '.phpcs.xml.dist'
+      - 'phpcs.xml.dist'
+      - '.github/dependabot.yml'
+      - '.github/workflows/cs.yml'
+      - 'images/**'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'LICENSE'
+      - '.phpcs.xml.dist'
+      - 'phpcs.xml.dist'
+      - '.github/dependabot.yml'
+      - '.github/workflows/cs.yml'
+      - 'images/**'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 


### PR DESCRIPTION
Only run the workflows when there is a chance that the result of the workflow run will be different from before.

The path selection is set up to cast a wide net to make the risk of the workflows not running when the build could potentially break as small as possible.

This means that, aside from files of the type being checked in the workflow changing, the workflow will also run when:
* The configuration used changes.
* Dependencies used in the workflow may potentially have changed.
* Composer scripts used in the workflow may potentially have changed.
* Shell scripts used in the workflow have changed.
* The workflow itself changes.
* Miscellaneous related files have changed.

Note: the lists of files _may_ include some files which don't currently exist in the repo (like `.eslintignore`) for consistency across workflows and to prevent issues if/when such file(s) would be introduced to the repo.

Also note that, as this repo does not contain a committed `composer.lock` file, the path selection is done via `paths-ignore` instead of via `paths`!