### PR TITLE
132 whip php 81 improvements

### DIFF
--- a/src/Whip_MessageDismisser.php
+++ b/src/Whip_MessageDismisser.php
@@ -59,4 +59,16 @@ class Whip_MessageDismisser {
 	public function isDismissed() {
 		return ( $this->currentTime <= ( $this->storage->get() + $this->threshold ) );
 	}
+
+	/**
+	 * Checks the nonce.
+	 *
+	 * @param string $nonce  The nonce to check.
+	 * @param string $action The action to check.
+	 *
+	 * @return bool True when the nonce is valid.
+	 */
+	public function verifyNonce( $nonce, $action ) {
+		return wp_verify_nonce( $nonce, $action );
+	}
 }

--- a/src/Whip_WPMessageDismissListener.php
+++ b/src/Whip_WPMessageDismissListener.php
@@ -40,8 +40,10 @@ class Whip_WPMessageDismissListener implements Whip_Listener {
 	 */
 	public function listen() {
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is verified in the dismisser.
 		$action = ( isset( $_GET['action'] ) && is_string( $_GET['action'] ) ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : null;
-		$nonce  = ( isset( $_GET['nonce'] ) && is_string( $_GET['nonce'] ) ) ? sanitize_text_field( wp_unslash( $_GET['nonce'] ) ) : null;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is verified in the dismisser.
+		$nonce = ( isset( $_GET['nonce'] ) && is_string( $_GET['nonce'] ) ) ? sanitize_text_field( wp_unslash( $_GET['nonce'] ) ) : null;
 
 		if ( $action === self::ACTION_NAME && $this->dismisser->verifyNonce( $nonce, self::ACTION_NAME ) ) {
 			$this->dismisser->dismiss();

--- a/src/Whip_WPMessageDismissListener.php
+++ b/src/Whip_WPMessageDismissListener.php
@@ -39,10 +39,11 @@ class Whip_WPMessageDismissListener implements Whip_Listener {
 	 * @return void
 	 */
 	public function listen() {
-		$action = filter_input( INPUT_GET, 'action' );
-		$nonce  = filter_input( INPUT_GET, 'nonce' );
 
-		if ( $action === self::ACTION_NAME && wp_verify_nonce( $nonce, self::ACTION_NAME ) ) {
+		$action = ( isset( $_GET['action'] ) && is_string( $_GET['action'] ) ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : null;
+		$nonce  = ( isset( $_GET['nonce'] ) && is_string( $_GET['nonce'] ) ) ? sanitize_text_field( wp_unslash( $_GET['nonce'] ) ) : null;
+
+		if ( $action === self::ACTION_NAME && $this->dismisser->verify_nonce( $nonce, self::ACTION_NAME ) ) {
 			$this->dismisser->dismiss();
 		}
 	}

--- a/src/Whip_WPMessageDismissListener.php
+++ b/src/Whip_WPMessageDismissListener.php
@@ -43,7 +43,7 @@ class Whip_WPMessageDismissListener implements Whip_Listener {
 		$action = ( isset( $_GET['action'] ) && is_string( $_GET['action'] ) ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : null;
 		$nonce  = ( isset( $_GET['nonce'] ) && is_string( $_GET['nonce'] ) ) ? sanitize_text_field( wp_unslash( $_GET['nonce'] ) ) : null;
 
-		if ( $action === self::ACTION_NAME && $this->dismisser->verify_nonce( $nonce, self::ACTION_NAME ) ) {
+		if ( $action === self::ACTION_NAME && $this->dismisser->verifyNonce( $nonce, self::ACTION_NAME ) ) {
 			$this->dismisser->dismiss();
 		}
 	}

--- a/tests/WPMessageDismissListenerTest.php
+++ b/tests/WPMessageDismissListenerTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * WHIP libary test file.
+ *
+ * @package Yoast\WHIP
+ */
+
+/**
+ * Message Dismiss Listener unit tests.
+ *
+ * @coversDefaultClass Whip_WPMessageDismissListener
+ */
+class WPMessageDismissListener extends Whip_TestCase {
+
+	/**
+	 * Tests the listen method.
+	 *
+	 * @covers ::listen
+	 *
+	 * @dataProvider listenProvider
+	 *
+	 * @param string $action The action to test.
+	 * @param string $nonce The nonce to test.
+	 * @param int    $verifyNonceTimes The times to call wp_verify_nonce.
+	 * @param bool   $isCorrectNonce Whether the nonce is correct.
+	 * @param bool   $dismissTimes The times to call dismiss.
+	 */
+	public function testDismiss( $action, $nonce, $verifyNonceTimes, $isCorrectNonce, $dismissTimes ) {
+		$dismisser = $this->getMockBuilder( 'Whip_MessageDismisser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new Whip_WPMessageDismissListener( $dismisser );
+
+		$_GET['action'] = $action;
+		$_GET['nonce']  = $nonce;
+
+		$dismisser->expects( $this->exactly( $verifyNonceTimes ) )
+				->method( 'verify_nonce' )
+				->with( $nonce, $action )
+				->willReturn( $isCorrectNonce );
+
+		$dismisser->expects( $this->exactly( $dismissTimes ) )
+				->method( 'dismiss' );
+
+		$instance->listen();
+	}
+
+	/**
+	 * Data provider for testDismiss.
+	 *
+	 * @return array
+	 */
+	public function listenProvider() {
+		return array(
+			'correct action and nonce' => array(
+				'action'                => Whip_WPMessageDismissListener::ACTION_NAME,
+				'nonce'                 => 'the_right_nonce',
+				'verifyNonceTimes'      => 1,
+				'isCorrectNonce'        => true,
+				'dismissTimes'          => 1,
+			),
+			'incorrect action correct nonce' => array(
+				'action'                => 'wrong_action',
+				'nonce'                 => 'the_right_nonce',
+				'verifyNonceTimes'      => 0,
+				'isCorrectNonce'        => false,
+				'dismissTimes'          => 0,
+			),
+			'correct action incorrect nonce' => array(
+				'action'                => Whip_WPMessageDismissListener::ACTION_NAME,
+				'nonce'                 => 'wrong_nonce',
+				'verifyNonceTimes'      => 1,
+				'isCorrectNonce'        => false,
+				'dismissTimes'          => 0,
+			),
+			'incorrect action and nonce' => array(
+				'action'                => 'wrong_action',
+				'nonce'                 => 'wrong_nonce',
+				'verifyNonceTimes'      => 0,
+				'isCorrectNonce'        => false,
+				'dismissTimes'          => 0,
+			),
+		);
+	}
+}

--- a/tests/WPMessageDismissListenerTest.php
+++ b/tests/WPMessageDismissListenerTest.php
@@ -36,7 +36,7 @@ class WPMessageDismissListener extends Whip_TestCase {
 		$_GET['nonce']  = $nonce;
 
 		$dismisser->expects( $this->exactly( $verifyNonceTimes ) )
-				->method( 'verify_nonce' )
+				->method( 'verifyNonce' )
 				->with( $nonce, $action )
 				->willReturn( $isCorrectNonce );
 

--- a/tests/doubles/WPCoreFunctionsMock.php
+++ b/tests/doubles/WPCoreFunctionsMock.php
@@ -30,3 +30,25 @@ function __( $message ) {
 function esc_url( $url ) {
 	return $url;
 }
+
+/**
+ * Mock for sanitize_text_field.
+ *
+ * @param string $text The text to be sanitize.
+ *
+ * @return string The text that was sanitized.
+ */
+function sanitize_text_field( $text ) {
+	return $text;
+}
+
+/**
+ * Mock for wp_unslash.
+ *
+ * @param string $string The string to be wp_unslash.
+ *
+ * @return string The string that was unslashed.
+ */
+function wp_unslash( $string ) {
+	return $string;
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Remove `filter_input` usage.

## Summary

This PR can be summarized in the following changelog entry:

* Removes `filter_input` usage for PHP 8.1 improvements.

## Relevant technical choices:

* Wrapped the `wp_verify_nonce` in the `Whip_MessageDismisser` for testing purposes.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This PR has only unit tests.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #132
