### PR TITLE
Composer: various tweaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,5 +58,12 @@
 		"coverage": [
 			"@php ./vendor/phpunit/phpunit/phpunit"
 		]
+	},
+	"scripts-descriptions": {
+		"lint": "Check the PHP files for parse errors.",
+		"check-cs": "Check the PHP files for code style violations and best practices.",
+		"fix-cs": "Auto-fix code style violations in the PHP files.",
+		"test": "Run the unit tests without code coverage.",
+		"coverage": "Run the unit tests with code coverage."
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,66 +1,66 @@
 {
-    "name": "yoast/whip",
-    "description": "A WordPress package to nudge users to upgrade their software versions (starting with PHP)",
-    "type": "library",
-    "homepage": "https://github.com/Yoast/whip",
-    "license": "GPL-3.0-or-later",
-    "authors": [
-        {
-            "name": "Team Yoast",
-            "email": "support@yoast.com"
-        }
-    ],
-    "support"    : {
-        "issues": "https://github.com/Yoast/whip/issues",
-        "source": "https://github.com/Yoast/whip"
-    },
-    "autoload": {
-        "files": [
-            "src/facades/wordpress.php"
-        ],
-        "classmap": [
-            "src/"
-        ]
-    },
-    "autoload-dev": {
-        "classmap": [
-            "tests/"
-        ]
-    },
-    "require": {
-        "php": ">=5.3"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^2.3.0"
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "scripts": {
-        "lint": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude node_modules --exclude .git"
-        ],
-        "config-yoastcs" : [
-            "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
-        ],
-        "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.3-"
-        ],
-        "fix-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
-        ],
-        "test": [
-            "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
-        ],
-        "coverage": [
-            "@php ./vendor/phpunit/phpunit/phpunit"
-        ]
-    }
+	"name": "yoast/whip",
+	"description": "A WordPress package to nudge users to upgrade their software versions (starting with PHP)",
+	"license": "GPL-3.0-or-later",
+	"type": "library",
+	"authors": [
+		{
+			"name": "Team Yoast",
+			"email": "support@yoast.com"
+		}
+	],
+	"homepage": "https://github.com/Yoast/whip",
+	"support": {
+		"issues": "https://github.com/Yoast/whip/issues",
+		"source": "https://github.com/Yoast/whip"
+	},
+	"require": {
+		"php": ">=5.3"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+		"roave/security-advisories": "dev-master",
+		"yoast/yoastcs": "^2.3.0"
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"autoload": {
+		"classmap": [
+			"src/"
+		],
+		"files": [
+			"src/facades/wordpress.php"
+		]
+	},
+	"autoload-dev": {
+		"classmap": [
+			"tests/"
+		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
+	"scripts": {
+		"lint": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude node_modules --exclude .git"
+		],
+		"config-yoastcs": [
+			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
+		],
+		"check-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.3-"
+		],
+		"fix-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+		],
+		"test": [
+			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+		],
+		"coverage": [
+			"@php ./vendor/phpunit/phpunit/phpunit"
+		]
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -46,10 +46,6 @@
 		"lint": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude node_modules --exclude .git"
 		],
-		"config-yoastcs": [
-			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
-		],
 		"check-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.3-"
 		],


### PR DESCRIPTION
### Composer: normalize the file

Well, mostly (scripts are not alphabetized, but still grouped by task).

Note: this is done as a one-time only action. The normalize script will **_not_** be run in CI to enforce normalization.

Style has been standardized to `--indent-style=tab --indent-size=1`.

Ref: https://github.com/ergebnis/composer-normalize

### Composer: remove redundant script

This script has been superseded by the Composer plugin handling this automatically.

### Composer: add script descriptions

These descriptions will be used when a list of the available scripts is requested on the command-line using the `composer list` or `composer run -l` commands.

These descriptions also help document the different scripts for the maintainers of the `composer.json` file.

Ref: https://getcomposer.org/doc/articles/scripts.md#custom-descriptions-