### PR TITLE
GH Actions: enable linting and testing against PHP 8.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ['5.4', '5.5', '5.6', '7.0', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php_version: ['5.4', '5.5', '5.6', '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.3']
         coverage: [false]
 
         # Run code coverage only on high/medium/low PHP.


### PR DESCRIPTION
All tests pass at this time (and that should stay that way), so no need to `continue-on-error`.