### PR TITLE
Docs: various improvements

### DIFF
--- a/src/Whip_Host.php
+++ b/src/Whip_Host.php
@@ -40,6 +40,7 @@ class Whip_Host {
 	 * In a non-WordPress content this function just returns the passed name.
 	 *
 	 * @param string $name The current name of the host.
+	 *
 	 * @return string The filtered name of the host.
 	 */
 	private static function filterName( $name ) {
@@ -96,6 +97,7 @@ class Whip_Host {
 	 * In a non-WordPress context this function just returns a link to the Yoast hosting page.
 	 *
 	 * @param string $url The previous URL.
+	 *
 	 * @return string The new URL to the hosting overview page.
 	 */
 	private static function filterHostingPageUrl( $url ) {

--- a/src/Whip_MessageDismisser.php
+++ b/src/Whip_MessageDismisser.php
@@ -46,6 +46,8 @@ class Whip_MessageDismisser {
 
 	/**
 	 * Saves the version number to the storage to indicate the message as being dismissed.
+	 *
+	 * @return void
 	 */
 	public function dismiss() {
 		$this->storage->set( $this->currentTime );

--- a/src/Whip_MessageDismisser.php
+++ b/src/Whip_MessageDismisser.php
@@ -20,7 +20,7 @@ class Whip_MessageDismisser {
 	/**
 	 * The current time.
 	 *
-	 * @var string
+	 * @var int
 	 */
 	protected $currentTime;
 

--- a/src/Whip_MessageFormatter.php
+++ b/src/Whip_MessageFormatter.php
@@ -14,6 +14,7 @@ final class Whip_MessageFormatter {
 	 * Wraps a piece of text in HTML strong tags.
 	 *
 	 * @param string $toWrap The text to wrap.
+	 *
 	 * @return string The wrapped text.
 	 */
 	public static function strong( $toWrap ) {
@@ -24,6 +25,7 @@ final class Whip_MessageFormatter {
 	 * Wraps a piece of text in HTML p tags.
 	 *
 	 * @param string $toWrap The text to wrap.
+	 *
 	 * @return string The wrapped text.
 	 */
 	public static function paragraph( $toWrap ) {
@@ -34,6 +36,7 @@ final class Whip_MessageFormatter {
 	 * Wraps a piece of text in HTML p and strong tags.
 	 *
 	 * @param string $toWrap The text to wrap.
+	 *
 	 * @return string The wrapped text.
 	 */
 	public static function strongParagraph( $toWrap ) {

--- a/src/Whip_MessagesManager.php
+++ b/src/Whip_MessagesManager.php
@@ -23,6 +23,8 @@ class Whip_MessagesManager {
 	 * Adds a message to the Messages Manager.
 	 *
 	 * @param Whip_Message $message The message to add.
+	 *
+	 * @return void
 	 */
 	public function addMessage( Whip_Message $message ) {
 		$whipVersion = require __DIR__ . '/configs/version.php';
@@ -50,6 +52,8 @@ class Whip_MessagesManager {
 
 	/**
 	 * Deletes all messages.
+	 *
+	 * @return void
 	 */
 	public function deleteMessages() {
 		unset( $GLOBALS['whip_messages'] );

--- a/src/Whip_RequirementsChecker.php
+++ b/src/Whip_RequirementsChecker.php
@@ -57,6 +57,8 @@ class Whip_RequirementsChecker {
 	 * Adds a requirement to the list of requirements if it doesn't already exist.
 	 *
 	 * @param Whip_Requirement $requirement The requirement to add.
+	 *
+	 * @return void
 	 */
 	public function addRequirement( Whip_Requirement $requirement ) {
 		// Only allow unique entries to ensure we're not checking specific combinations multiple times.
@@ -122,6 +124,8 @@ class Whip_RequirementsChecker {
 
 	/**
 	 * Checks if all requirements are fulfilled and adds a message to the message manager if necessary.
+	 *
+	 * @return void
 	 */
 	public function check() {
 		foreach ( $this->requirements as $requirement ) {
@@ -140,6 +144,8 @@ class Whip_RequirementsChecker {
 	 * Adds a message to the message manager for requirements that cannot be fulfilled.
 	 *
 	 * @param Whip_Requirement $requirement The requirement that cannot be fulfilled.
+	 *
+	 * @return void
 	 */
 	private function addMissingRequirementMessage( Whip_Requirement $requirement ) {
 		switch ( $requirement->component() ) {

--- a/src/Whip_VersionRequirement.php
+++ b/src/Whip_VersionRequirement.php
@@ -111,6 +111,8 @@ class Whip_VersionRequirement implements Whip_Requirement {
 	 * @param string $version   The component version.
 	 * @param string $operator  The operator to use when comparing version.
 	 *
+	 * @return void
+	 *
 	 * @throws Whip_EmptyProperty       When any of the parameters is empty.
 	 * @throws Whip_InvalidOperatorType When the $operator parameter is invalid.
 	 * @throws Whip_InvalidType         When any of the parameters is not of the expected type.

--- a/src/facades/wordpress.php
+++ b/src/facades/wordpress.php
@@ -10,6 +10,8 @@ if ( ! function_exists( 'whip_wp_check_versions' ) ) {
 	 * Facade to quickly check if version requirements are met.
 	 *
 	 * @param array $requirements The requirements to check.
+	 *
+	 * @return void
 	 */
 	function whip_wp_check_versions( $requirements ) {
 		// Only show for admin users.

--- a/src/interfaces/Whip_MessagePresenter.php
+++ b/src/interfaces/Whip_MessagePresenter.php
@@ -12,6 +12,8 @@ interface Whip_MessagePresenter {
 
 	/**
 	 * Renders the message.
+	 *
+	 * @return void
 	 */
 	public function renderMessage();
 }

--- a/src/messages/Whip_BasicMessage.php
+++ b/src/messages/Whip_BasicMessage.php
@@ -42,6 +42,8 @@ class Whip_BasicMessage implements Whip_Message {
 	 *
 	 * @param string $body Message body.
 	 *
+	 * @return void
+	 *
 	 * @throws Whip_EmptyProperty When the $body parameter is empty.
 	 * @throws Whip_InvalidType   When the $body parameter is not of the expected type.
 	 */

--- a/src/presenters/Whip_WPMessagePresenter.php
+++ b/src/presenters/Whip_WPMessagePresenter.php
@@ -48,6 +48,8 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 	 * Registers hooks to WordPress.
 	 *
 	 * This is a separate function so you can control when the hooks are registered.
+	 *
+	 * @return void
 	 */
 	public function registerHooks() {
 		add_action( 'admin_notices', array( $this, 'renderMessage' ) );
@@ -59,6 +61,7 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 	 * @deprecated 1.2.0 Use the Whip_WPMessagePresenter::registerHooks() method instead.
 	 * @codeCoverageIgnore
 	 *
+	 * @return void
 	 * @phpcs:disable Generic.NamingConventions.CamelCapsFunctionName
 	 */
 	public function register_hooks() {
@@ -68,6 +71,8 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 
 	/**
 	 * Renders the messages present in the global to notices.
+	 *
+	 * @return void
 	 */
 	public function renderMessage() {
 		$dismissListener = new Whip_WPMessageDismissListener( $this->dismisser );

--- a/src/presenters/Whip_WPMessagePresenter.php
+++ b/src/presenters/Whip_WPMessagePresenter.php
@@ -58,6 +58,7 @@ class Whip_WPMessagePresenter implements Whip_MessagePresenter {
 	 *
 	 * @deprecated 1.2.0 Use the Whip_WPMessagePresenter::registerHooks() method instead.
 	 * @codeCoverageIgnore
+	 *
 	 * @phpcs:disable Generic.NamingConventions.CamelCapsFunctionName
 	 */
 	public function register_hooks() {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -14,6 +14,8 @@ class ConfigurationTest extends Whip_TestCase {
 	 * Tests the creation of a Whip_Configuration with invalid input.
 	 *
 	 * @covers Whip_Configuration::__construct
+	 *
+	 * @return void
 	 */
 	public function testItThrowsAnErrorIfAFaultyConfigurationIsPassed() {
 		$this->expectExceptionHelper( 'Whip_InvalidType', 'Configuration should be of type array. Found string.' );
@@ -25,6 +27,8 @@ class ConfigurationTest extends Whip_TestCase {
 	 * Tests if Whip_Configuration correctly returns -1 when passed an unknown requirement.
 	 *
 	 * @covers Whip_Configuration::configuredVersion
+	 *
+	 * @return void
 	 */
 	public function testItReturnsANegativeNumberIfRequirementCannotBeFound() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );
@@ -44,6 +48,8 @@ class ConfigurationTest extends Whip_TestCase {
 	 * Tests if Whip_Configuration correctly returns the version number when passed a valid requirement.
 	 *
 	 * @covers Whip_Configuration::configuredVersion
+	 *
+	 * @return void
 	 */
 	public function testItReturnsAnEntryIfRequirementIsFound() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );
@@ -63,6 +69,8 @@ class ConfigurationTest extends Whip_TestCase {
 	 * Tests if hasRequirementConfigures correctly returns true/false when called with valid/invalid values.
 	 *
 	 * @covers Whip_Configuration::hasRequirementConfigured
+	 *
+	 * @return void
 	 */
 	public function testIfRequirementIsConfigured() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -51,7 +51,7 @@ class MessageDismisserTest extends Whip_TestCase {
 	/**
 	 * Provides array with test values.
 	 *
-	 * @return array[]
+	 * @return array<string, array<int|bool>>
 	 */
 	public function versionNumbersProvider() {
 		return array(

--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -15,6 +15,8 @@ class MessageDismisserTest extends Whip_TestCase {
 	 *
 	 * @covers Whip_MessageDismisser::__construct
 	 * @covers Whip_MessageDismisser::dismiss
+	 *
+	 * @return void
 	 */
 	public function testDismiss() {
 		$currentTime = time();
@@ -39,6 +41,8 @@ class MessageDismisserTest extends Whip_TestCase {
 	 * @param int  $savedTime   The saved time.
 	 * @param int  $currentTime The current time.
 	 * @param bool $expected    The expected value.
+	 *
+	 * @return void
 	 */
 	public function testIsDismissibleWithVersions( $savedTime, $currentTime, $expected ) {
 		$storage = new Whip_DismissStorageMock();

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -14,6 +14,8 @@ class MessageTest extends Whip_TestCase {
 	 * Tests if Whip_BasicMessage correctly handles a string for its body argument.
 	 *
 	 * @covers Whip_BasicMessage::body
+	 *
+	 * @return void
 	 */
 	public function testMessageHasBody() {
 		$message = new Whip_BasicMessage( 'This is a message' );
@@ -25,6 +27,8 @@ class MessageTest extends Whip_TestCase {
 	 * Tests if an Exception is correctly thrown when an empty string is passed as argument.
 	 *
 	 * @covers Whip_BasicMessage::validateParameters
+	 *
+	 * @return void
 	 */
 	public function testMessageCannotBeEmpty() {
 		$this->expectExceptionHelper( 'Whip_EmptyProperty', 'Message body cannot be empty.' );
@@ -36,6 +40,8 @@ class MessageTest extends Whip_TestCase {
 	 * Tests if an Exception is correctly thrown when an invalid type is passed as argument.
 	 *
 	 * @covers Whip_BasicMessage::validateParameters
+	 *
+	 * @return void
 	 */
 	public function testMessageMustBeString() {
 		$this->expectExceptionHelper( 'Whip_InvalidType', 'Message body should be of type string. Found integer.' );

--- a/tests/MessagesManagerTest.php
+++ b/tests/MessagesManagerTest.php
@@ -15,6 +15,8 @@ class MessagesManagerTest extends Whip_TestCase {
 	 * without a message, true when given a message.
 	 *
 	 * @covers Whip_MessagesManager::hasMessages
+	 *
+	 * @return void
 	 */
 	public function testHasMessages() {
 		$manager = new Whip_MessagesManager();

--- a/tests/RequirementsCheckerTest.php
+++ b/tests/RequirementsCheckerTest.php
@@ -15,6 +15,8 @@ class RequirementsCheckerTest extends Whip_TestCase {
 	 *
 	 * @covers Whip_RequirementsChecker::addRequirement
 	 * @covers Whip_RequirementsChecker::totalRequirements
+	 *
+	 * @return void
 	 */
 	public function testItReceivesAUsableRequirementObject() {
 		$checker = new Whip_RequirementsChecker();
@@ -29,6 +31,8 @@ class RequirementsCheckerTest extends Whip_TestCase {
 	 *
 	 * @covers   Whip_RequirementsChecker::addRequirement
 	 * @requires PHP 7
+	 *
+	 * @return void
 	 */
 	public function testItThrowsAnTypeErrorWhenInvalidRequirementIsPassed() {
 		if ( version_compare( phpversion(), '7.0', '<' ) ) {
@@ -52,6 +56,8 @@ class RequirementsCheckerTest extends Whip_TestCase {
 	 * Tests if Whip_RequirementsChecker throws an error when passed an invalid requirement.
 	 *
 	 * @covers Whip_RequirementsChecker::addRequirement
+	 *
+	 * @return void
 	 */
 	public function testItThrowsAnTypeErrorWhenInvalidRequirementIsPassedInPHP5() {
 		if ( version_compare( phpversion(), '7.0', '>=' ) ) {
@@ -76,6 +82,8 @@ class RequirementsCheckerTest extends Whip_TestCase {
 	 *
 	 * @covers Whip_RequirementsChecker::addRequirement
 	 * @covers Whip_RequirementsChecker::totalRequirements
+	 *
+	 * @return void
 	 */
 	public function testItOnlyContainsUniqueComponents() {
 		$checker = new Whip_RequirementsChecker();
@@ -97,6 +105,8 @@ class RequirementsCheckerTest extends Whip_TestCase {
 	 *
 	 * @covers Whip_RequirementsChecker::addRequirement
 	 * @covers Whip_RequirementsChecker::requirementExistsForComponent
+	 *
+	 * @return void
 	 */
 	public function testIfRequirementExists() {
 		$checker = new Whip_RequirementsChecker();
@@ -117,6 +127,8 @@ class RequirementsCheckerTest extends Whip_TestCase {
 	 * @covers Whip_RequirementsChecker::check
 	 * @covers Whip_RequirementsChecker::hasMessages
 	 * @covers Whip_RequirementsChecker::getMostRecentMessage
+	 *
+	 * @return void
 	 */
 	public function testCheckIfPHPRequirementIsNotFulfilled() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => 4 ) );
@@ -149,6 +161,8 @@ class RequirementsCheckerTest extends Whip_TestCase {
 	 * @covers Whip_RequirementsChecker::addRequirement
 	 * @covers Whip_RequirementsChecker::check
 	 * @covers Whip_RequirementsChecker::getMostRecentMessage
+	 *
+	 * @return void
 	 */
 	public function testCheckIfRequirementIsFulfilled() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => phpversion() ) );
@@ -168,6 +182,8 @@ class RequirementsCheckerTest extends Whip_TestCase {
 	 * @covers Whip_RequirementsChecker::check
 	 * @covers Whip_RequirementsChecker::getMostRecentMessage
 	 * @covers Whip_RequirementsChecker::hasMessages
+	 *
+	 * @return void
 	 */
 	public function testCheckIfRequirementIsNotFulfilled() {
 		$checker = new Whip_RequirementsChecker( array( 'mysql' => 4 ) );
@@ -192,6 +208,8 @@ class RequirementsCheckerTest extends Whip_TestCase {
 	 * @covers Whip_RequirementsChecker::addRequirement
 	 * @covers Whip_RequirementsChecker::check
 	 * @covers Whip_RequirementsChecker::hasMessages
+	 *
+	 * @return void
 	 */
 	public function testCheckIfRequirementIsFulfilledWithSpecificComparison() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => 4 ) );
@@ -208,6 +226,8 @@ class RequirementsCheckerTest extends Whip_TestCase {
 	 * @covers Whip_RequirementsChecker::addRequirement
 	 * @covers Whip_RequirementsChecker::check
 	 * @covers Whip_RequirementsChecker::hasMessages
+	 *
+	 * @return void
 	 */
 	public function testCheckIfRequirementIsNotFulfilledWithSpecificComparison() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => 4 ) );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,7 +24,7 @@ class Whip_TestCase extends PHPUnit_Framework_TestCase {
 	 * cross-version compatible manner.
 	 *
 	 * @param string          $exception The class name of the exception to expect.
-	 * @param string|null     $message   Optional. The exception message to expect.
+	 * @param string          $message   Optional. The exception message to expect.
 	 * @param int|string|null $code      Optional. The exception code to expect.
 	 *
 	 * @return void

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -149,6 +149,8 @@ class VersionRequirementTest extends Whip_TestCase {
 
 	/**
 	 * Provides data to test fromCompareString with.
+	 *
+	 * @return array<string, array<string|array<string>>>
 	 */
 	public function dataFromCompareString() {
 		return array(

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -16,6 +16,8 @@ class VersionRequirementTest extends Whip_TestCase {
 	 *
 	 * @covers Whip_VersionRequirement::component
 	 * @covers Whip_VersionRequirement::version
+	 *
+	 * @return void
 	 */
 	public function testNameAndVersionAreNotEmpty() {
 		$requirement = new Whip_VersionRequirement( 'php', '5.2' );
@@ -29,6 +31,8 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with an empty component.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
+	 *
+	 * @return void
 	 */
 	public function testComponentCannotBeEmpty() {
 		$this->expectExceptionHelper( 'Whip_EmptyProperty', 'Component cannot be empty.' );
@@ -41,6 +45,8 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with an empty version.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
+	 *
+	 * @return void
 	 */
 	public function testVersionCannotBeEmpty() {
 		$this->expectExceptionHelper( 'Whip_EmptyProperty', 'Version cannot be empty.' );
@@ -53,6 +59,8 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with a false type for a component.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
+	 *
+	 * @return void
 	 */
 	public function testComponentMustBeString() {
 		$this->expectExceptionHelper( 'Whip_InvalidType', 'Component should be of type string. Found integer.' );
@@ -65,6 +73,8 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with a false type for a version.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
+	 *
+	 * @return void
 	 */
 	public function testVersionMustBeString() {
 		$this->expectExceptionHelper( 'Whip_InvalidType', 'Version should be of type string. Found integer.' );
@@ -77,6 +87,8 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with an empty operator.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
+	 *
+	 * @return void
 	 */
 	public function testOperatorCannotBeEmpty() {
 		$this->expectExceptionHelper( 'Whip_EmptyProperty', 'Operator cannot be empty.' );
@@ -89,6 +101,8 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with a false type for an operator.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
+	 *
+	 * @return void
 	 */
 	public function testOperatorMustBeString() {
 		$this->expectExceptionHelper( 'Whip_InvalidType', 'Operator should be of type string. Found integer.' );
@@ -101,6 +115,8 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * is created with an invalid operator.
 	 *
 	 * @covers Whip_VersionRequirement::validateParameters
+	 *
+	 * @return void
 	 */
 	public function testOperatorMustBeValid() {
 		$this->expectExceptionHelper(
@@ -117,6 +133,8 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * @covers Whip_VersionRequirement::component
 	 * @covers Whip_VersionRequirement::version
 	 * @covers Whip_VersionRequirement::operator
+	 *
+	 * @return void
 	 */
 	public function testGettingComponentProperties() {
 		$requirement = new Whip_VersionRequirement( 'php', '5.6' );
@@ -138,6 +156,8 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * @param string $expectation   The expected output string.
 	 * @param string $component     The component for this version requirement.
 	 * @param string $compareString The comparison string for this version requirement.
+	 *
+	 * @return void
 	 */
 	public function testFromCompareString( $expectation, $component, $compareString ) {
 		$requirement = Whip_VersionRequirement::fromCompareString( $component, $compareString );
@@ -170,6 +190,8 @@ class VersionRequirementTest extends Whip_TestCase {
 	 * with an invalid comparison string.
 	 *
 	 * @covers Whip_VersionRequirement::fromCompareString
+	 *
+	 * @return void
 	 */
 	public function testFromCompareStringException() {
 		$this->expectExceptionHelper(

--- a/tests/WPMessageDismissListenerTest.php
+++ b/tests/WPMessageDismissListenerTest.php
@@ -49,7 +49,7 @@ class WPMessageDismissListener extends Whip_TestCase {
 	/**
 	 * Data provider for testDismiss.
 	 *
-	 * @return array
+	 * @return array<string, array<string, mixed>>
 	 */
 	public function listenProvider() {
 		return array(

--- a/tests/WPMessageDismissListenerTest.php
+++ b/tests/WPMessageDismissListenerTest.php
@@ -24,6 +24,8 @@ class WPMessageDismissListener extends Whip_TestCase {
 	 * @param int    $verifyNonceTimes The times to call wp_verify_nonce.
 	 * @param bool   $isCorrectNonce   Whether the nonce is correct.
 	 * @param int    $dismissTimes     The times to call dismiss.
+	 *
+	 * @return void
 	 */
 	public function testDismiss( $action, $nonce, $verifyNonceTimes, $isCorrectNonce, $dismissTimes ) {
 		$dismisser = $this->getMockBuilder( 'Whip_MessageDismisser' )

--- a/tests/WPMessageDismissListenerTest.php
+++ b/tests/WPMessageDismissListenerTest.php
@@ -23,7 +23,7 @@ class WPMessageDismissListener extends Whip_TestCase {
 	 * @param string $nonce            The nonce to test.
 	 * @param int    $verifyNonceTimes The times to call wp_verify_nonce.
 	 * @param bool   $isCorrectNonce   Whether the nonce is correct.
-	 * @param bool   $dismissTimes     The times to call dismiss.
+	 * @param int    $dismissTimes     The times to call dismiss.
 	 */
 	public function testDismiss( $action, $nonce, $verifyNonceTimes, $isCorrectNonce, $dismissTimes ) {
 		$dismisser = $this->getMockBuilder( 'Whip_MessageDismisser' )

--- a/tests/WPMessageDismissListenerTest.php
+++ b/tests/WPMessageDismissListenerTest.php
@@ -19,11 +19,11 @@ class WPMessageDismissListener extends Whip_TestCase {
 	 *
 	 * @dataProvider listenProvider
 	 *
-	 * @param string $action The action to test.
-	 * @param string $nonce The nonce to test.
+	 * @param string $action           The action to test.
+	 * @param string $nonce            The nonce to test.
 	 * @param int    $verifyNonceTimes The times to call wp_verify_nonce.
-	 * @param bool   $isCorrectNonce Whether the nonce is correct.
-	 * @param bool   $dismissTimes The times to call dismiss.
+	 * @param bool   $isCorrectNonce   Whether the nonce is correct.
+	 * @param bool   $dismissTimes     The times to call dismiss.
 	 */
 	public function testDismiss( $action, $nonce, $verifyNonceTimes, $isCorrectNonce, $dismissTimes ) {
 		$dismisser = $this->getMockBuilder( 'Whip_MessageDismisser' )


### PR DESCRIPTION
### Docs: various small formatting fixes

Align parameter descriptions in docblocks and other minor formatting fixes.

### Docs: improve type specificity

### Docs: fix incorrect type

### Docs: add missing return type void annotations 