### PR TITLE
Tests: make dataproviders `static`

### DIFF
--- a/tests/MessageDismisserTest.php
+++ b/tests/MessageDismisserTest.php
@@ -57,7 +57,7 @@ final class MessageDismisserTest extends Whip_TestCase {
 	 *
 	 * @return array<string, array<int|bool>>
 	 */
-	public function versionNumbersProvider() {
+	public static function versionNumbersProvider() {
 		return array(
 			'-2weeks' => array( strtotime( '-2weeks' ), time(), true ),
 			'-4weeks' => array( strtotime( '-4weeks' ), time(), true ),

--- a/tests/VersionRequirementTest.php
+++ b/tests/VersionRequirementTest.php
@@ -172,7 +172,7 @@ final class VersionRequirementTest extends Whip_TestCase {
 	 *
 	 * @return array<string, array<string|array<string>>>
 	 */
-	public function dataFromCompareString() {
+	public static function dataFromCompareString() {
 		return array(
 			'php > 5.5'  => array( array( 'php', '5.5', '>' ), 'php', '>5.5' ),
 			'php >= 5.5' => array( array( 'php', '5.5', '>=' ), 'php', '>=5.5' ),

--- a/tests/WPMessageDismissListenerTest.php
+++ b/tests/WPMessageDismissListenerTest.php
@@ -53,7 +53,7 @@ final class WPMessageDismissListener extends Whip_TestCase {
 	 *
 	 * @return array<string, array<string, mixed>>
 	 */
-	public function listenProvider() {
+	public static function listenProvider() {
 		return array(
 			'correct action and nonce' => array(
 				'action'                => Whip_WPMessageDismissListener::ACTION_NAME,


### PR DESCRIPTION
As of PHPUnit 10, data providers are (again) expected to be `static` methods.

This updates the test suite to respect that.