### PR TITLE
Whip_MessageDismisser::verifyNonce(): bug fix

### DIFF
--- a/src/Whip_MessageDismisser.php
+++ b/src/Whip_MessageDismisser.php
@@ -71,6 +71,6 @@ class Whip_MessageDismisser {
 	 * @return bool True when the nonce is valid.
 	 */
 	public function verifyNonce( $nonce, $action ) {
-		return wp_verify_nonce( $nonce, $action );
+		return (bool) wp_verify_nonce( $nonce, $action );
 	}
 }


### PR DESCRIPTION
The method is documented as returning a boolean value, but the `wp_verify_nonce()` function returns `int|false`.

Fixed now.

Ref: https://developer.wordpress.org/reference/functions/wp_verify_nonce/

Note: as the test suite does not test with a real WP setup, this bug currently cannot easily be proven, nor safeguarded via a test.

The `WHIP_WPMessageDismissListener::listen()` method uses this function and does have a test, but mocks away the `Whip_MessageDismisser::verifyNonce()` method. The mock correctly returns `true|false`, but that isn't what the reality was doing.

/cc @vraja-pro 