### PR TITLE
Whip_WPMessageDismissListener::listen(): bug fix

### DIFF
--- a/src/Whip_WPMessageDismissListener.php
+++ b/src/Whip_WPMessageDismissListener.php
@@ -43,7 +43,7 @@ class Whip_WPMessageDismissListener implements Whip_Listener {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is verified in the dismisser.
 		$action = ( isset( $_GET['action'] ) && is_string( $_GET['action'] ) ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : null;
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is verified in the dismisser.
-		$nonce = ( isset( $_GET['nonce'] ) && is_string( $_GET['nonce'] ) ) ? sanitize_text_field( wp_unslash( $_GET['nonce'] ) ) : null;
+		$nonce = ( isset( $_GET['nonce'] ) && is_string( $_GET['nonce'] ) ) ? sanitize_text_field( wp_unslash( $_GET['nonce'] ) ) : '';
 
 		if ( $action === self::ACTION_NAME && $this->dismisser->verifyNonce( $nonce, self::ACTION_NAME ) ) {
 			$this->dismisser->dismiss();


### PR DESCRIPTION
The `Whip_MessageDismisser::verifyNonce()` method expects to be passed a `string`, but if the nonce was not available, it would be passed `null`, which could lead to PHP 8.1 "passing null to non-nullable" deprecation notices (though in this case wouldn't as the underlying [`wp_verify_nonce()`](https://developer.wordpress.org/reference/functions/wp_verify_nonce/) function casts the value to string anyway).

All the same, it is a bug. Fixed now.

Note: as the test suite does not test with a real WP setup, this bug currently cannot easily be safeguarded via a test.

The `WHIP_WPMessageDismissListener::listen()` method does have tests, but mocks away the `Whip_MessageDismisser::verifyNonce()` method, so the mock was hiding the bug.

/cc @vraja-pro