### PR TITLE
Whip_Requirement: be explicit about all expected methods

### DIFF
--- a/src/interfaces/Whip_Requirement.php
+++ b/src/interfaces/Whip_Requirement.php
@@ -16,4 +16,18 @@ interface Whip_Requirement {
 	 * @return string The component name.
 	 */
 	public function component();
+
+	/**
+	 * Gets the components version defined for the requirement.
+	 *
+	 * @return string
+	 */
+	public function version();
+
+	/**
+	 * Gets the operator to use when comparing version numbers.
+	 *
+	 * @return string The comparison operator.
+	 */
+	public function operator();
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -33,7 +33,7 @@ final class ConfigurationTest extends Whip_TestCase {
 	public function testItReturnsANegativeNumberIfRequirementCannotBeFound() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );
 		$requirement   = $this->getMockBuilder( 'Whip_Requirement' )
-			->setMethods( array( 'component' ) )
+			->setMethods( array( 'component', 'version', 'operator' ) )
 			->getMock();
 
 		$requirement
@@ -54,7 +54,7 @@ final class ConfigurationTest extends Whip_TestCase {
 	public function testItReturnsAnEntryIfRequirementIsFound() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );
 		$requirement   = $this->getMockBuilder( 'Whip_Requirement' )
-			->setMethods( array( 'component' ) )
+			->setMethods( array( 'component', 'version', 'operator' ) )
 			->getMock();
 
 		$requirement
@@ -75,7 +75,7 @@ final class ConfigurationTest extends Whip_TestCase {
 	public function testIfRequirementIsConfigured() {
 		$configuration = new Whip_Configuration( array( 'php' => '5.6' ) );
 		$requirement   = $this->getMockBuilder( 'Whip_Requirement' )
-			->setMethods( array( 'component' ) )
+			->setMethods( array( 'component', 'version', 'operator' ) )
 			->getMock();
 
 		$requirement
@@ -84,7 +84,7 @@ final class ConfigurationTest extends Whip_TestCase {
 			->will( $this->returnValue( 'php' ) );
 
 		$falseRequirement = $this->getMockBuilder( 'Whip_Requirement' )
-			->setMethods( array( 'component' ) )
+			->setMethods( array( 'component', 'version', 'operator' ) )
 			->getMock();
 
 		$falseRequirement


### PR DESCRIPTION
The `Whip_RequirementsChecker::requirementIsFulfilled()` method makes unconditional calls to the `version()` and `operator()` methods on an object implementing `Whip_Requirement`, so these methods ought to be made explicitly required for classes implementing the `Whip_Requirement` interface.

Fixed now.

Includes updating some tests to match.

Note: this change may warrant a new major release!