### PR TITLE
Tests: minor modernization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"php": ">=5.3"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+		"phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
 		"roave/security-advisories": "dev-master",
 		"yoast/yoastcs": "^2.3.0"
 	},

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,10 +5,12 @@
  * @package Yoast\WHIP
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Base test case class from which all tests should extend.
  */
-abstract class Whip_TestCase extends PHPUnit_Framework_TestCase {
+abstract class Whip_TestCase extends TestCase {
 
 	/**
 	 * Helper method to test exceptions.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,22 +5,6 @@
  * @package Yoast\WHIP
  */
 
-/*
- * PHPUnit cross version compatibility.
- *
- * The classes in PHPUnit have been renamed to namespaced classes.
- * The namespaced alias for the TestCase class is available as of PHPUnit 5.4 and as of
- * PHPUnit 6.0, the non-namespaced versions are no longer available.
- * As PHPUnit 6.0 requires PHP 7 anyway, the PHP 5.3 function class_alias() will be available,
- * so we can use it to alias the class back to the old class name.
- */
-if ( class_exists( 'PHPUnit\Framework\TestCase' ) === true
-	&& class_exists( 'PHPUnit_Framework_TestCase' ) === false
-) {
-	// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.class_aliasFound
-	class_alias( 'PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase' );
-}
-
 if ( file_exists( __DIR__ . '/../vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/../vendor/autoload.php';
 }


### PR DESCRIPTION
As of PHPUnit 4.8.36 and PHPUnit 5.7.21, PHPUnit contains a _forward_ compatibility layer for the most commonly used PHPUnit classes to make handling the change to namespaced classes in PHPUnit 6.0 more straight-forward.

As support for PHP 5.2 has been dropped from this plugin, we can now use this forward-compatibility layer and no longer need to create a class alias for the PHPUnit `TestCase` ourselves.