### PR TITLE
Composer.json: add link to security policy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/Yoast/whip",
 	"support": {
 		"issues": "https://github.com/Yoast/whip/issues",
-		"source": "https://github.com/Yoast/whip"
+		"source": "https://github.com/Yoast/whip",
+		"security": "https://yoast.com/security-program/"
 	},
 	"require": {
 		"php": ">=5.3"


### PR DESCRIPTION
This is a new feature available since Composer 2.6.0, which was released a little while ago.

When this key is added, it will also show a link to the security policy on Packagist.

Refs:
* https://github.com/composer/composer/releases/tag/2.6.0
* https://github.com/composer/composer/pull/11271
* https://github.com/composer/packagist/pull/1353