### PR TITLE
GH Actions/test: PHP 8.3 has been released

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ['5.4', '5.5', '5.6', '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.3']
+        php_version: ['5.4', '5.5', '5.6', '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         coverage: [false]
 
         # Run code coverage only on high/medium/low PHP.
@@ -50,7 +50,7 @@ jobs:
           coverage: true
         - php_version: 7.1
           coverage: true
-        - php_version: 8.2
+        - php_version: 8.3
           coverage: true
 
     name: "Lint and test: PHP ${{ matrix.php_version }}"


### PR DESCRIPTION
The tests were already being run against PHP 8.3 and not _allowed to fail_.

However, for this workflow, code coverage should run against the highest PHP version. This commit makes it so.