### PR TITLE
QA/Docs: minor fixes

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -20,7 +20,7 @@ class Configuration {
 	/**
 	 * Configuration constructor.
 	 *
-	 * @param array<string> $configuration The configuration to use.
+	 * @param array<string, string> $configuration The configuration to use.
 	 *
 	 * @throws InvalidType When the $configuration parameter is not of the expected type.
 	 */

--- a/src/RequirementsChecker.php
+++ b/src/RequirementsChecker.php
@@ -44,8 +44,8 @@ class RequirementsChecker {
 	/**
 	 * RequirementsChecker constructor.
 	 *
-	 * @param array<Requirement> $configuration The configuration to check.
-	 * @param string             $textdomain    The text domain to use for translations.
+	 * @param array<string, string> $configuration The configuration to check.
+	 * @param string                $textdomain    The text domain to use for translations.
 	 *
 	 * @throws InvalidType When the $configuration parameter is not of the expected type.
 	 */

--- a/tests/Unit/RequirementsCheckerTest.php
+++ b/tests/Unit/RequirementsCheckerTest.php
@@ -134,7 +134,7 @@ final class RequirementsCheckerTest extends TestCase {
 	 * @return void
 	 */
 	public function testCheckIfPHPRequirementIsNotFulfilled() {
-		$checker = new RequirementsChecker( array( 'php' => 4 ) );
+		$checker = new RequirementsChecker( array( 'php' => '4' ) );
 
 		$checker->addRequirement( new VersionRequirement( 'php', '5.6' ) );
 		$checker->check();
@@ -189,7 +189,7 @@ final class RequirementsCheckerTest extends TestCase {
 	 * @return void
 	 */
 	public function testCheckIfRequirementIsNotFulfilled() {
-		$checker = new RequirementsChecker( array( 'mysql' => 4 ) );
+		$checker = new RequirementsChecker( array( 'mysql' => '4' ) );
 
 		$checker->addRequirement( new VersionRequirement( 'mysql', '5.6' ) );
 		$checker->check();
@@ -215,7 +215,7 @@ final class RequirementsCheckerTest extends TestCase {
 	 * @return void
 	 */
 	public function testCheckIfRequirementIsFulfilledWithSpecificComparison() {
-		$checker = new RequirementsChecker( array( 'php' => 4 ) );
+		$checker = new RequirementsChecker( array( 'php' => '4' ) );
 
 		$checker->addRequirement( new VersionRequirement( 'php', '5.2', '<' ) );
 		$checker->check();
@@ -233,7 +233,7 @@ final class RequirementsCheckerTest extends TestCase {
 	 * @return void
 	 */
 	public function testCheckIfRequirementIsNotFulfilledWithSpecificComparison() {
-		$checker = new RequirementsChecker( array( 'php' => 4 ) );
+		$checker = new RequirementsChecker( array( 'php' => '4' ) );
 
 		$checker->addRequirement( new VersionRequirement( 'php', '5.2', '>=' ) );
 		$checker->check();


### PR DESCRIPTION
### Docs: improve types

### RequirementsCheckerTest: pass the correct type

Not that it really matters in this case as strict types is not being used, so an int will juggle to a string just fine, but still.