### PR TITLE
Changelog: prepare for the release of version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,26 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.0.0] - 2023-12-28
+### Added
+* Tested against PHP 8.3. [#138], [#150]
+
 ### Changed
 * All the source classes are now namespaced under `Yoast\WHIPv2`. The version number in the namespaced will be bumped up with every major version. [#157]
     The classes have also been renamed to remove the `Whip_` prefix, and the folders' names have been capitalized to follow the PSR-4 standard.
 * The `Requirement` interface now explicitly declares the following two additional methods: `version() ` and `operator()` and classes implementing the interface should ensure these methods are available. [#146]
 * General housekeeping.
 
-### Fixed
+### Removed
+* The deprecated `Whip_WPMessagePresenter:register_hooks()` method has been removed. [#158]
 
+### Fixed
 * Compatibility with PHP >= 8.2: prevent a deprecation notice about dynamic properties usage from being thrown in the `RequirementsChecker` class. [#117]
 
+[#158]: https://github.com/Yoast/whip/pull/158
 [#157]: https://github.com/Yoast/whip/pull/157
+[#150]: https://github.com/Yoast/whip/pull/150
 [#146]: https://github.com/Yoast/whip/pull/146
+[#138]: https://github.com/Yoast/whip/pull/138
 [#117]: https://github.com/Yoast/whip/pull/117
 
 ## [1.2.0] - 2021-07-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.0] - 2023-12-28
+### Changed
+* All the source classes are now namespaced under `Yoast\WHIPv2`. The version number in the namespaced will be bumped up with every major version. [#157]
+    The classes have also been renamed to remove the `Whip_` prefix, and the folders' names have been capitalized to follow the PSR-4 standard.
+* The `Requirement` interface now declares explicitly two methods: `version() ` and `operator()`. [#146]
+* General housekeeping.
+
+### Fixed
+
+* Compatibility with PHP >= 8.2: prevent a deprecation notice about dynamic properties usage from being thrown in the `RequirementsChecker` class. [#117]
+
+[#157]: https://github.com/Yoast/whip/pull/157
+[#146]: https://github.com/Yoast/whip/pull/146
+[#117]: https://github.com/Yoast/whip/pull/117
+
 ## [1.2.0] - 2021-07-20
 
 :warning: This version drops support for PHP 5.2!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * All the source classes are now namespaced under `Yoast\WHIPv2`. The version number in the namespaced will be bumped up with every major version. [#157]
     The classes have also been renamed to remove the `Whip_` prefix, and the folders' names have been capitalized to follow the PSR-4 standard.
-* The `Requirement` interface now declares explicitly two methods: `version() ` and `operator()`. [#146]
+* The `Requirement` interface now explicitly declares the following two additional methods: `version() ` and `operator()` and classes implementing the interface should ensure these methods are available. [#146]
 * General housekeeping.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 * Compatibility with PHP >= 8.2: prevent a deprecation notice about dynamic properties usage from being thrown in the `RequirementsChecker` class. [#117]
+* Security hardening: added sanitization to the notification dismiss action. [#131]
 
 [#158]: https://github.com/Yoast/whip/pull/158
 [#157]: https://github.com/Yoast/whip/pull/157
 [#150]: https://github.com/Yoast/whip/pull/150
 [#146]: https://github.com/Yoast/whip/pull/146
 [#138]: https://github.com/Yoast/whip/pull/138
+[#131]: https://github.com/Yoast/whip/pull/131
 [#117]: https://github.com/Yoast/whip/pull/117
 
 ## [1.2.0] - 2021-07-20


### PR DESCRIPTION
The release date has been tentatively set to next Thursday, December 28, 2023.

