### PR TITLE
CS/check thresholds: require exact match for thresholds

### DIFF
--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -155,6 +155,11 @@ class Actions {
 			$above_threshold = false;
 		}
 
+		$threshold_exact = true;
+		if ( \strpos( $phpcs_output, ' than the threshold, great job!' ) !== false ) {
+			$threshold_exact = false;
+		}
+
 		/*
 		 * Don't run the branch check in CI/GH Actions as it prevents the errors from being shown inline.
 		 * The GH Actions script will run this via a separate script step.
@@ -169,7 +174,15 @@ class Actions {
 			@\passthru( 'composer check-branch-cs' );
 		}
 
-		exit( ( $above_threshold === true || $return > 2 ) ? $return : 0 );
+		$exit_code = 0;
+		if ( $above_threshold === true || $return > 2 ) {
+			$exit_code = $return;
+		}
+		elseif ( $threshold_exact === false ) {
+			$exit_code = 128;
+		}
+
+		exit( $exit_code );
 	}
 
 	/**


### PR DESCRIPTION
This changes the implementation of the coding standards threshold check to require that both the `YOASTCS_THRESHOLD_ERRORS` environment variable, as well as the `YOASTCS_THRESHOLD_WARNINGS` environment variable match the current status exactly.

This prevents PR A fixing some issues and forgetting to update the threshold, which then would allow PR B to introduce new issues.

_Note: WHIP currently doesn't use the threshold check in CI as the package is "clean". This commit just makes sure that the threshold implementation is in line with that in other plugins for consistency._