### PR TITLE
Composer: prevent a lock file from being created

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
+		},
+		"lock": false
 	},
 	"scripts": {
 		"lint": [


### PR DESCRIPTION
Composer 1.10.0 introduced a `lock` config option, which, when set to `false` will prevent a `composer.lock` file from being created and will ignore it when one exists.

This is a useful option for libraries such as this where the `lock` file has no meaning.

It also makes life easier for contributors as they don't have to remember that for this repo they should use `composer update` instead of `composer install`. Both will now work the same.

Refs:
https://getcomposer.org/doc/06-config.md#lock