### PR TITLE
GH Actions: enable linting and testing against PHP 8.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,16 +43,16 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ['5.4', '5.5', '5.6', '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php_version: ['5.4', '5.5', '5.6', '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         coverage: [false]
 
         # Run code coverage only on high/medium/low PHP.
         include:
         - php_version: 5.3
           coverage: true
-        - php_version: 7.1
+        - php_version: 7.2
           coverage: true
-        - php_version: 8.3
+        - php_version: 8.4
           coverage: true
 
     name: "Lint and test: PHP ${{ matrix.php_version }}"


### PR DESCRIPTION
* As the PHP 8.4 builds pass and the PHP 8.4 release is expected later this month, the builds are not _allowed to fail_.
* Update PHP version on which code coverage is run (high should now be 8.4).