### PR TITLE
GH Actions: add actionlint job

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -10,7 +10,6 @@ on:
       - 'LICENSE'
       - 'phpunit.xml.dist'
       - '.github/dependabot.yml'
-      - '.github/workflows/test.yml'
       - 'images/**'
   pull_request:
     paths-ignore:
@@ -20,7 +19,6 @@ on:
       - 'LICENSE'
       - 'phpunit.xml.dist'
       - '.github/dependabot.yml'
-      - '.github/workflows/test.yml'
       - 'images/**'
   # Allow manually triggering the workflow.
   workflow_dispatch:
@@ -32,6 +30,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  actionlint:
+    name: 'Lint GH Action workflows'
+    uses: Yoast/.github/.github/workflows/reusable-actionlint.yml@main
+
   checkcs:
     name: 'Check code style'
     runs-on: ubuntu-latest


### PR DESCRIPTION
This job checks the GH Actions workflows against syntax errors and other problems.