### PR TITLE
Composer: normalize the file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,12 +36,12 @@
 		]
 	},
 	"autoload-dev": {
-		"classmap": [
-			"config/"
-		],
 		"psr-4": {
 			"Yoast\\WHIP\\Tests\\": "tests/"
-		}
+		},
+		"classmap": [
+			"config/"
+		]
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
Well, mostly (scripts are not alphabetized, but still grouped by task).

Note: this is done as a one-time only action. The normalize script will **_not_** be run in CI to enforce normalization.

Style has been standardized to `--indent-style=tab --indent-size=1`.

Ref: https://github.com/ergebnis/composer-normalize