### PR TITLE
Tests: fix broken `@covers` tags

### DIFF
--- a/tests/Unit/RequirementsCheckerTest.php
+++ b/tests/Unit/RequirementsCheckerTest.php
@@ -32,7 +32,7 @@ final class RequirementsCheckerTest extends TestCase {
 	/**
 	 * Tests if RequirementsChecker throws an error when passed an invalid requirement.
 	 *
-	 * @covers   RequirementsChecker::addRequirement
+	 * @covers   \Yoast\WHIPv2\RequirementsChecker::addRequirement
 	 * @requires PHP 7
 	 *
 	 * @return void

--- a/tests/Unit/WPMessageDismissListenerTest.php
+++ b/tests/Unit/WPMessageDismissListenerTest.php
@@ -7,7 +7,7 @@ use Yoast\WHIPv2\WPMessageDismissListener;
 /**
  * Message Dismiss Listener unit tests.
  *
- * @coversDefaultClass WPMessageDismissListener
+ * @coversDefaultClass \Yoast\WHIPv2\WPMessageDismissListener
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Acronym throws the count off.
  */
@@ -16,7 +16,7 @@ final class WPMessageDismissListenerTest extends TestCase {
 	/**
 	 * Tests the listen method.
 	 *
-	 * @covers \Yoast\WHIPv2\WPMessageDismissListener::listen
+	 * @covers ::listen
 	 *
 	 * @dataProvider listenProvider
 	 *


### PR DESCRIPTION
`@covers[DefaultClass]` should always contain fully qualified names for PHPUnit to be able to recognize them properly.