### PR TITLE
Composer: update to YoastCS 3.4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
 		"phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
 		"roave/security-advisories": "dev-master",
-		"yoast/yoastcs": "^3.4.0"
+		"yoast/yoastcs": "^3.4.2"
 	},
 	"minimum-stability": "alpha",
 	"prefer-stable": true,


### PR DESCRIPTION
A few dependencies of YoastCS have released security fixes.

This updates enforces the use of CS dependency versions which include these fixes.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/3.4.2